### PR TITLE
OS2 Feature Parity

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,10 +121,13 @@ jar {
 task apiJar(type: Jar, dependsOn: classes) {
     classifier = "api"
     from sourceSets.main.allSource
-    exclude("mmd/orespawn/impl/**")
-    exclude("mmd/orespawn/json/**")
-    exclude("mmd/orespawn/world/**")
-    exclude("mmd/orespawn/*.java")
+    exclude("com/mcmoddev/orespawn/impl/**")
+    exclude("com/mcmoddev/orespawn/impl/features/**")
+    exclude("com/mcmoddev/orespawn/json/**")
+    exclude("com/mcmoddev/orespawn/world/**")
+    exclude("com/mcmoddev/orespawn/commands/**")
+    exclude("com/mcmoddev/orespawn/data/**")
+    exclude("com/mcmoddev/orespawn/*.java")
 }
 
 task devJar(type: Jar) {
@@ -214,19 +217,7 @@ curseforge {
 }
 
 String getModFile() {
-    String path = "";
-    FileTree tree = fileTree(dir: "src/main/java")
-    tree.include "**/*.java"
-    tree.visit { element ->
-        if (element.file.isFile()) {
-            element.file.eachLine { String s ->
-                s = s.trim();
-                if (s.startsWith("@Mod")) {
-                    path = "src/main/java/$element.relativePath"
-                }
-            }
-        }
-    }
+    String path = "src/main/java/com/mcmoddev/orespawn/data/Constants.java";
     return path;
 }
 

--- a/src/main/java/com/mcmoddev/orespawn/EventHandlers.java
+++ b/src/main/java/com/mcmoddev/orespawn/EventHandlers.java
@@ -1,0 +1,113 @@
+package com.mcmoddev.orespawn;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Random;
+
+import com.mcmoddev.orespawn.api.DimensionLogic;
+import com.mcmoddev.orespawn.api.OreSpawnAPI;
+import com.mcmoddev.orespawn.api.SpawnEntry;
+import com.mcmoddev.orespawn.api.SpawnLogic;
+import com.mcmoddev.orespawn.data.Config;
+import com.mcmoddev.orespawn.data.Constants;
+import com.mcmoddev.orespawn.data.DefaultOregenParameters;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraft.nbt.NBTTagString;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.chunk.IChunkGenerator;
+import net.minecraft.world.chunk.IChunkProvider;
+import net.minecraftforge.event.world.ChunkDataEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+public class EventHandlers {
+
+	@SubscribeEvent
+	public void onChunkSave(ChunkDataEvent.Save ev) {
+		NBTTagCompound dataTag = ev.getData().getCompoundTag(Constants.CHUNK_TAG_NAME);
+		NBTTagList ores = new NBTTagList();
+		NBTTagList features = new NBTTagList();
+		features.appendTag( new NBTTagString("orespawn:default"));
+		
+		for( Entry<String, SpawnLogic> ent : OreSpawn.API.getAllSpawnLogic().entrySet() ) {
+			SpawnLogic log = ent.getValue();
+			if( log.getAllDimensions().containsKey(ev.getWorld().provider.getDimension()) ) {
+				Collection<SpawnEntry> vals = log.getDimension(ev.getWorld().provider.getDimension()).getEntries();
+				for( SpawnEntry s : vals ) {
+					ores.appendTag( new NBTTagString( s.getState().getBlock().getRegistryName().toString()) );
+				}
+			}
+			if( log.getAllDimensions().containsKey(OreSpawnAPI.DIMENSION_WILDCARD) ) {
+				Collection<SpawnEntry> vals = log.getDimension(OreSpawnAPI.DIMENSION_WILDCARD).getEntries();
+				for( SpawnEntry s : vals ) {
+					ores.appendTag( new NBTTagString( s.getState().getBlock().getRegistryName().toString()) );
+				}				
+			}
+		}
+		
+		dataTag.setTag(Constants.ORE_TAG, ores);
+		dataTag.setTag(Constants.FEATURES_TAG, features);
+		ev.getData().setTag(Constants.CHUNK_TAG_NAME, dataTag);
+	}
+	
+	@SubscribeEvent
+	public void onChunkLoad(ChunkDataEvent.Load ev) {
+		if( Config.getBoolean(Constants.RETROGEN_KEY) ) {
+			NBTTagCompound chunkTag = ev.getData().getCompoundTag(Constants.CHUNK_TAG_NAME);
+			int count = chunkTag==null?0:chunkTag.getTagList(Constants.ORE_TAG, 8).tagCount();
+			if( count != countOres(ev.getWorld().provider.getDimension()) ||
+					Config.getBoolean(Constants.FORCE_RETROGEN_KEY)) {
+				doRegen(ev.getWorld(), ev.getChunk().x, ev.getChunk().z);
+			}
+		}
+	}
+
+	private void doRegen( World w, int chunkX, int chunkZ ) {
+		IChunkProvider prov = w.getChunkProvider();
+		IChunkGenerator gen = w.provider.createChunkGenerator();
+		Random rand = w.rand;
+		
+		List<SpawnEntry> spawns = new ArrayList<>();
+		for( SpawnLogic sL : OreSpawn.API.getAllSpawnLogic().values() ) {
+			DimensionLogic dLM = sL.getDimension(w.provider.getDimension());
+			DimensionLogic dLW = sL.getDimension(OreSpawnAPI.DIMENSION_WILDCARD);
+			
+			spawns.addAll(dLM.getEntries());
+			if( !dLW.getEntries().isEmpty() ) {
+				spawns.addAll(dLW.getEntries());
+			}
+		}
+		for( SpawnEntry sE : spawns ) {
+			Biome biome = w.getBiomeProvider().getBiome(new BlockPos(chunkX*16, 64,chunkZ*16));
+			if( sE.getBiomes().contains(biome) || sE.getBiomes() == Collections.EMPTY_LIST || sE.getBiomes().size() == 0 ) {
+				retrogen(rand, chunkX, chunkZ, w, prov, gen, sE);
+			}
+		}
+	}
+	
+	private void retrogen(Random rand, int chunkX, int chunkZ, World world, IChunkProvider prov, IChunkGenerator gen, SpawnEntry s) {
+		DefaultOregenParameters p = new DefaultOregenParameters(s);
+		s.getFeatureGen().generate(rand, chunkX, chunkZ, world, gen, prov, p);
+	}
+
+	private int countOres(int dim) {
+		int acc = 0;
+		for( Entry<String, SpawnLogic> sL : OreSpawn.API.getAllSpawnLogic().entrySet() ) {
+			if( sL.getValue().getAllDimensions().containsKey(dim) ) {
+				acc += sL.getValue().getAllDimensions().get(dim).getEntries().size();
+			}
+			if( sL.getValue().getAllDimensions().containsKey(OreSpawnAPI.DIMENSION_WILDCARD) ) {
+				acc += sL.getValue().getAllDimensions().get(OreSpawnAPI.DIMENSION_WILDCARD).getEntries().size();
+			}
+		}
+		return acc;
+	}
+	
+	
+}

--- a/src/main/java/com/mcmoddev/orespawn/OreSpawn.java
+++ b/src/main/java/com/mcmoddev/orespawn/OreSpawn.java
@@ -5,15 +5,21 @@ import com.mcmoddev.orespawn.impl.OreSpawnImpl;
 import com.mcmoddev.orespawn.json.OS1Reader;
 import com.mcmoddev.orespawn.json.OS2Reader;
 import com.mcmoddev.orespawn.json.OS2Writer;
+import com.mcmoddev.orespawn.api.OreSpawnAPI;
+import com.mcmoddev.orespawn.commands.AddOreCommand;
+import com.mcmoddev.orespawn.commands.ClearChunkCommand;
+import com.mcmoddev.orespawn.commands.DumpBiomesCommand;
+import com.mcmoddev.orespawn.data.Config;
+import com.mcmoddev.orespawn.api.SpawnLogic;
 
 import java.nio.file.Paths;
+
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import com.mcmoddev.orespawn.api.OreSpawnAPI;
-import com.mcmoddev.orespawn.commands.ClearChunkCommand;
-import com.mcmoddev.orespawn.data.Config;
 
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.Mod;
@@ -42,6 +48,7 @@ public class OreSpawn {
     public static Logger LOGGER = LogManager.getFormatterLogger(Constants.MODID);
     public final static OreSpawnAPI API = new OreSpawnImpl();
     public static final OS2Writer writer = new OS2Writer();
+    public static final EventHandlers eventHandlers = new EventHandlers();
     
     // TODO: add some form of storage for JSON here
     // TODO: add config loading -- partially done
@@ -52,6 +59,10 @@ public class OreSpawn {
     	
     	if( Config.getBoolean(Constants.RETROGEN_KEY) ) {
     		// TODO: setup stuff for retrogen
+    	}
+    	
+    	if( Config.getBoolean(Constants.RETROGEN_KEY) ) {
+    		MinecraftForge.EVENT_BUS.register(eventHandlers);
     	}
     	
     	OS1Reader.loadEntries(Paths.get(ev.getSuggestedConfigurationFile().toPath().getParent().toString(),"orespawn"));
@@ -71,13 +82,20 @@ public class OreSpawn {
     }
     
     @EventHandler
-    public void onIMC(FMLInterModComms.IMCEvent ev) {
-    	// TODO: Handle IMC
+    public void onIMC(FMLInterModComms.IMCEvent event) {
+        event.getMessages().stream().filter(message -> message.key.equalsIgnoreCase("api")).forEach(message -> {
+            Optional<Function<OreSpawnAPI, SpawnLogic>> value = message.getFunctionValue(OreSpawnAPI.class, SpawnLogic.class);
+            if (OreSpawn.API.getSpawnLogic(message.getSender()) == null && value.isPresent()) {
+                OreSpawn.API.registerSpawnLogic(message.getSender(), value.get().apply(OreSpawn.API));
+            }
+        });
     }
-
+    
     @EventHandler
     public void onServerStarting(FMLServerStartingEvent ev) {
     	// TODO: Register Commands
     	ev.registerServerCommand(new ClearChunkCommand());
+    	ev.registerServerCommand(new DumpBiomesCommand());
+    	ev.registerServerCommand(new AddOreCommand());
     }
 }

--- a/src/main/java/com/mcmoddev/orespawn/OreSpawn.java
+++ b/src/main/java/com/mcmoddev/orespawn/OreSpawn.java
@@ -51,15 +51,10 @@ public class OreSpawn {
     public static final EventHandlers eventHandlers = new EventHandlers();
     
     // TODO: add some form of storage for JSON here
-    // TODO: add config loading -- partially done
 
     @EventHandler
     public void preInit(FMLPreInitializationEvent ev) {
     	Config.loadConfig();
-    	
-    	if( Config.getBoolean(Constants.RETROGEN_KEY) ) {
-    		// TODO: setup stuff for retrogen
-    	}
     	
     	if( Config.getBoolean(Constants.RETROGEN_KEY) ) {
     		MinecraftForge.EVENT_BUS.register(eventHandlers);
@@ -67,7 +62,8 @@ public class OreSpawn {
     	
     	OS1Reader.loadEntries(Paths.get(ev.getSuggestedConfigurationFile().toPath().getParent().toString(),"orespawn"));
     	OS2Reader.loadEntries();
-    	// TODO: Bind stuff for standard gen regardless
+
+    	FMLInterModComms.sendFunctionMessage("orespawn", "api", "com.mcmoddev.orespawn.data.VanillaOrespawn");
     }
 
     @EventHandler
@@ -76,7 +72,6 @@ public class OreSpawn {
 
     @EventHandler
     public void postInit(FMLPostInitializationEvent ev) {
-    	// TODO: OS2 does a data-write here, we should too
     	writer.writeSpawnEntries();
     	Config.saveConfig();
     }
@@ -93,7 +88,6 @@ public class OreSpawn {
     
     @EventHandler
     public void onServerStarting(FMLServerStartingEvent ev) {
-    	// TODO: Register Commands
     	ev.registerServerCommand(new ClearChunkCommand());
     	ev.registerServerCommand(new DumpBiomesCommand());
     	ev.registerServerCommand(new AddOreCommand());

--- a/src/main/java/com/mcmoddev/orespawn/commands/AddOreCommand.java
+++ b/src/main/java/com/mcmoddev/orespawn/commands/AddOreCommand.java
@@ -1,0 +1,126 @@
+package com.mcmoddev.orespawn.commands;
+
+import com.google.gson.*;
+import com.mcmoddev.orespawn.api.OreSpawnAPI;
+import com.mcmoddev.orespawn.util.StateUtil;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.CommandException;
+import net.minecraft.command.ICommand;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemStack;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.EnumHand;
+import net.minecraft.util.text.TextComponentString;
+import org.apache.commons.io.Charsets;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
+
+import java.io.File;
+import java.io.IOException;
+
+public class AddOreCommand extends CommandBase {
+    @Override
+    public String getName() {
+        return "addore";
+    }
+
+    @Override
+    public String getUsage(ICommandSender sender) {
+        return "/addore <file> <dimension|all>";
+    }
+
+    @Override
+    public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
+        if (!(sender instanceof EntityPlayer)) {
+            throw new CommandException("Only players can use this command");
+        }
+
+        EntityPlayer player = (EntityPlayer) sender;
+        ItemStack stack = player.getHeldItem(EnumHand.MAIN_HAND);
+
+        if (stack == null) {
+            throw new CommandException("You have no item in your main hand");
+        } else if (!(stack.getItem() instanceof ItemBlock)) {
+            throw new CommandException("The item in your main hand isn't a block");
+        } else if (args.length != 2) {
+            throw new CommandException(this.getUsage(sender));
+        }
+
+        File file = new File(".", "orespawn" + File.separator + args[0] + ".json");
+        JsonParser parser = new JsonParser();
+        IBlockState state = ((ItemBlock) stack.getItem()).getBlock().getStateFromMeta(stack.getItemDamage());
+
+        if (!file.exists()) {
+            throw new CommandException("That file doesn't exist" + (args[0].endsWith(".json") ? " (don't add .json)" : ""));
+        }
+
+        int dimension = OreSpawnAPI.DIMENSION_WILDCARD;
+
+        try {
+            if (!args[1].equals("all")) {
+                dimension = Integer.parseInt(args[1]);
+            }
+        } catch (NumberFormatException e) {
+            throw new CommandException(args[1] + " isn't a valid dimension");
+        }
+
+        JsonObject ore = new JsonObject();
+        ore.addProperty("block", state.getBlock().getRegistryName().toString());
+        ore.addProperty("state", StateUtil.serializeState(state));
+        ore.addProperty("size", 25);
+        ore.addProperty("variation", 12);
+        ore.addProperty("frequency", 20);
+        ore.addProperty("min_height", 0);
+        ore.addProperty("max_height", 128);
+
+        try {
+            JsonArray json = parser.parse(FileUtils.readFileToString(file)).getAsJsonArray();
+
+            for (JsonElement element : json) {
+                JsonObject object = element.getAsJsonObject();
+
+                if (object.has("dimension") ? dimension == object.get("dimension").getAsInt() : dimension == OreSpawnAPI.DIMENSION_WILDCARD) {
+                    object.get("ores").getAsJsonArray().add(ore);
+                    this.saveFile(json, file);
+
+                    return;
+                }
+            }
+
+            JsonObject object = new JsonObject();
+
+            if (dimension != OreSpawnAPI.DIMENSION_WILDCARD) {
+                object.addProperty("dimension", dimension);
+            }
+
+            JsonArray array = new JsonArray();
+            array.add(ore);
+            object.add("ores", array);
+
+            this.saveFile(json, file);
+        } catch (IOException e) {
+            throw new CommandException("Failed to read the json file");
+        }
+
+        player.sendStatusMessage(new TextComponentString("Added " + state.getBlock().getRegistryName().toString() + " to the json"), true);
+    }
+
+    private void saveFile(JsonArray array, File file) throws CommandException {
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        String json = gson.toJson(array);
+
+        try {
+            FileUtils.writeStringToFile(file, StringEscapeUtils.unescapeJson(json), Charsets.UTF_8);
+        } catch (IOException e) {
+            throw new CommandException("Failed to save the updated json file");
+        }
+    }
+
+    @Override
+    public int compareTo(ICommand command) {
+        return this.getName().compareTo(command.getName());
+    }
+}

--- a/src/main/java/com/mcmoddev/orespawn/commands/ClearChunkCommand.java
+++ b/src/main/java/com/mcmoddev/orespawn/commands/ClearChunkCommand.java
@@ -10,6 +10,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
+import net.minecraft.util.text.TextComponentString;
 import net.minecraft.world.chunk.Chunk;
 
 public class ClearChunkCommand extends CommandBase {
@@ -45,6 +46,7 @@ public class ClearChunkCommand extends CommandBase {
                 }
             }
         }
+        player.sendStatusMessage(new TextComponentString("chunk "+chunkPos.toString()+" cleared"), true);
     }
 
     @Override

--- a/src/main/java/com/mcmoddev/orespawn/commands/DumpBiomesCommand.java
+++ b/src/main/java/com/mcmoddev/orespawn/commands/DumpBiomesCommand.java
@@ -1,0 +1,57 @@
+package com.mcmoddev.orespawn.commands;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonPrimitive;
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.CommandException;
+import net.minecraft.command.ICommand;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.text.TextComponentString;
+import net.minecraft.world.biome.Biome;
+import net.minecraftforge.fml.common.registry.ForgeRegistries;
+import org.apache.commons.io.Charsets;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
+
+import java.io.File;
+import java.io.IOException;
+
+public class DumpBiomesCommand extends CommandBase {
+    @Override
+    public String getName() {
+        return "dumpbiomes";
+    }
+
+    @Override
+    public String getUsage(ICommandSender sender) {
+        return "/dumpbiomes";
+    }
+
+    @Override
+    public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
+        JsonArray array = new JsonArray();
+
+        for (Biome biome : ForgeRegistries.BIOMES) {
+            array.add(new JsonPrimitive(biome.getRegistryName().toString()));
+        }
+
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        String json = gson.toJson(array);
+
+        try {
+            FileUtils.writeStringToFile(new File(".", "biome_dump.json"), StringEscapeUtils.unescapeJson(json), Charsets.UTF_8);
+        } catch (IOException e) {
+            throw new CommandException("Failed to save the json file");
+        }
+
+        sender.sendMessage(new TextComponentString("Done"));
+    }
+
+    @Override
+    public int compareTo(ICommand command) {
+        return this.getName().compareTo(command.getName());
+    }
+}

--- a/src/main/java/com/mcmoddev/orespawn/data/Config.java
+++ b/src/main/java/com/mcmoddev/orespawn/data/Config.java
@@ -17,14 +17,17 @@ public class Config {
 		configuration = new Configuration(new File(Constants.CONFIG_FILE));
 		
 		// Load our Boolean Values
-		boolVals.put(Constants.RETROGEN_KEY, configuration.getBoolean(Constants.RETROGEN_KEY, Configuration.CATEGORY_GENERAL, true, "Do we have Retrogen active and generating anything different from the last run in already existing chunks ?"));
-		boolVals.put(Constants.FORCE_RETROGEN_KEY, configuration.getBoolean(Constants.FORCE_RETROGEN_KEY, Configuration.CATEGORY_GENERAL, true, "Force all chunks to retrogen regardless of anything else"));
+		boolVals.put(Constants.RETROGEN_KEY, configuration.getBoolean(Constants.RETROGEN_KEY, Configuration.CATEGORY_GENERAL, false, "Do we have Retrogen active and generating anything different from the last run in already existing chunks ?"));
+		boolVals.put(Constants.FORCE_RETROGEN_KEY, configuration.getBoolean(Constants.FORCE_RETROGEN_KEY, Configuration.CATEGORY_GENERAL, false, "Force all chunks to retrogen regardless of anything else"));
 		knownKeys.add(Constants.RETROGEN_KEY);
 		knownKeys.add(Constants.FORCE_RETROGEN_KEY);
 	}
 	
 	public static boolean getBoolean(String keyname) {
 		if( knownKeys.contains(keyname) && boolVals.containsKey(keyname) ) {
+			if(keyname.equals(Constants.RETROGEN_KEY) || keyname.equals(Constants.FORCE_RETROGEN_KEY)) {
+				return false;
+			}
 			return boolVals.get(keyname);
 		}
 		return false;

--- a/src/main/java/com/mcmoddev/orespawn/data/Constants.java
+++ b/src/main/java/com/mcmoddev/orespawn/data/Constants.java
@@ -7,4 +7,7 @@ public class Constants {
 	public static final String RETROGEN_KEY = "Retrogen";
 	public static final String CONFIG_FILE = "config/orespawn.cfg";
 	public static final String FORCE_RETROGEN_KEY = "Force Retrogen";
+	public static final String CHUNK_TAG_NAME = "MMD OreSpawn Data";
+	public static final String ORE_TAG = "ores";
+	public static final String FEATURES_TAG = "features";
 }

--- a/src/main/java/com/mcmoddev/orespawn/data/DefaultOregenParameters.java
+++ b/src/main/java/com/mcmoddev/orespawn/data/DefaultOregenParameters.java
@@ -1,5 +1,7 @@
 package com.mcmoddev.orespawn.data;
 
+import com.mcmoddev.orespawn.api.SpawnEntry;
+
 import net.minecraft.block.state.IBlockState;
 
 public class DefaultOregenParameters {
@@ -17,5 +19,14 @@ public class DefaultOregenParameters {
 		this.frequency = frequency;
 		this.variation = variation;
 		this.size = size;
+	}
+
+	public DefaultOregenParameters(SpawnEntry s) {
+		this.blockState = s.getState();
+		this.minHeight = s.getMinHeight();
+		this.maxHeight = s.getMaxHeight();
+		this.frequency = s.getFrequency();
+		this.variation = s.getVariation();
+		this.size = s.getSize();
 	}
 }

--- a/src/main/java/com/mcmoddev/orespawn/data/VanillaOrespawn.java
+++ b/src/main/java/com/mcmoddev/orespawn/data/VanillaOrespawn.java
@@ -1,0 +1,36 @@
+package com.mcmoddev.orespawn.data;
+
+import com.google.common.base.Function;
+import com.mcmoddev.orespawn.api.OreSpawnAPI;
+import com.mcmoddev.orespawn.api.SpawnLogic;
+
+import net.minecraft.block.BlockStone;
+import net.minecraft.init.Biomes;
+import net.minecraft.init.Blocks;
+
+public class VanillaOrespawn implements Function<OreSpawnAPI,SpawnLogic> {
+	@Override
+	public SpawnLogic apply(OreSpawnAPI api) {
+		SpawnLogic logic = api.createSpawnLogic();
+
+		logic.getDimension(-1)
+		.addOre(Blocks.QUARTZ_ORE.getDefaultState(), 15, 4, 7, 0, 128);
+
+		logic.getDimension(OreSpawnAPI.DIMENSION_WILDCARD)
+		.addOre(Blocks.COAL_ORE.getDefaultState(), 25, 12, 20, 0, 128)
+		.addOre(Blocks.IRON_ORE.getDefaultState(), 8, 4, 20, 0, 64)
+		.addOre(Blocks.GOLD_ORE.getDefaultState(), 8, 2, 2, 0, 32)
+		.addOre(Blocks.DIAMOND_ORE.getDefaultState(), 6, 3, 8, 0, 16)
+		.addOre(Blocks.REDSTONE_ORE.getDefaultState(), 6, 3, 8, 0, 16)
+		.addOre(Blocks.LAPIS_ORE.getDefaultState(), 5, 2, 1, 0, 32)
+		.addOre(Blocks.EMERALD_ORE.getDefaultState(), 1, 0, 8, 4, 32, Biomes.EXTREME_HILLS, Biomes.EXTREME_HILLS_EDGE)
+		.addOre(Blocks.DIRT.getDefaultState(), 112, 50, 10, 0, 255)
+		.addOre(Blocks.GRAVEL.getDefaultState(), 112, 50, 8, 0, 255)
+		.addOre(Blocks.STONE.getDefaultState().withProperty(BlockStone.VARIANT, BlockStone.EnumType.GRANITE), 112, 50, 10, 0, 255)
+		.addOre(Blocks.STONE.getDefaultState().withProperty(BlockStone.VARIANT, BlockStone.EnumType.DIORITE), 112, 50, 10, 0, 255)
+		.addOre(Blocks.STONE.getDefaultState().withProperty(BlockStone.VARIANT, BlockStone.EnumType.ANDESITE), 112, 50, 10, 0, 255);
+
+		return logic;
+	}
+
+}

--- a/src/main/java/mmd/orespawn/api/DimensionLogic.java
+++ b/src/main/java/mmd/orespawn/api/DimensionLogic.java
@@ -1,0 +1,16 @@
+package mmd.orespawn.api;
+
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.world.biome.Biome;
+
+import java.util.Collection;
+
+public interface DimensionLogic {
+    DimensionLogic addOre(IBlockState state, int size, int variation, float frequency, int minHeight, int maxHeight, Biome... biomes);
+    
+    DimensionLogic addOre(IBlockState state, int size, int variation, int frequency, int minHeight, int maxHeight, Biome... biomes);
+    
+    Collection<SpawnEntry> getEntries();
+
+    SpawnLogic end();
+}

--- a/src/main/java/mmd/orespawn/api/IFeature.java
+++ b/src/main/java/mmd/orespawn/api/IFeature.java
@@ -1,0 +1,14 @@
+package mmd.orespawn.api;
+
+import java.util.Random;
+
+import com.mcmoddev.orespawn.data.DefaultOregenParameters;
+
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.IChunkGenerator;
+import net.minecraft.world.chunk.IChunkProvider;
+
+public interface IFeature {
+	void generate(Random random, int chunkX, int chunkZ, World world, IChunkGenerator chunkGenerator,
+			IChunkProvider chunkProvider, DefaultOregenParameters p);
+}

--- a/src/main/java/mmd/orespawn/api/OreSpawnAPI.java
+++ b/src/main/java/mmd/orespawn/api/OreSpawnAPI.java
@@ -1,0 +1,17 @@
+package mmd.orespawn.api;
+
+import java.util.Map;
+
+import com.mcmoddev.orespawn.api.SpawnLogic;
+
+public interface OreSpawnAPI {
+    int DIMENSION_WILDCARD = "DIMENSION_WILDCARD".hashCode();
+
+    SpawnLogic createSpawnLogic();
+
+    SpawnLogic getSpawnLogic(String id);
+
+    Map<String, SpawnLogic> getAllSpawnLogic();
+    
+    void registerSpawnLogic(String name, SpawnLogic logic);
+}

--- a/src/main/java/mmd/orespawn/api/SpawnEntry.java
+++ b/src/main/java/mmd/orespawn/api/SpawnEntry.java
@@ -1,0 +1,24 @@
+package mmd.orespawn.api;
+
+import java.util.List;
+
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.world.biome.Biome;
+
+public interface SpawnEntry {
+    IBlockState getState();
+
+    int getSize();
+
+    int getVariation();
+
+    float getFrequency();
+
+    int getMinHeight();
+
+    int getMaxHeight();
+
+    List<Biome> getBiomes();
+    
+    IFeature getFeatureGen();
+}

--- a/src/main/java/mmd/orespawn/api/SpawnLogic.java
+++ b/src/main/java/mmd/orespawn/api/SpawnLogic.java
@@ -1,0 +1,9 @@
+package mmd.orespawn.api;
+
+import java.util.Map;
+
+public interface SpawnLogic {
+    DimensionLogic getDimension(int dimension);
+
+    Map<Integer, DimensionLogic> getAllDimensions();
+}


### PR DESCRIPTION
1) Retrogen is roughed in but hard-offlined as there is a StackOverflow crash bug that needs to be tracked down and stomped on
2) Hooks up the IMC handler so the IMC-based API that is in use in OS2 is now also in use with OS3 (fully functional)
3) Change build.gradle so it looks in the "Constants" class for the mod-version and pulls it from there rather than trying to find the same in the first file it finds the \@Mod annotation in
4) Add the VanillaOres API wrapper so that all vanilla ores are registered in the event that the "replace vanilla oregen" Config option is implemented and then turned on by a user we'll have them ready to gen.
5) Restory the legacy mmd.orespawn.api namespace but using the newer forms of the interfaces - this should, hopefully, stop users of the API from crashing if they are used with OS3 without having their code updated.

If/When Retrogen is corrected, this code will have all the functionality of OS2.