### PR TITLE
Full OreSpawn 2 parity

### DIFF
--- a/src/main/java/com/mcmoddev/orespawn/EventHandlers.java
+++ b/src/main/java/com/mcmoddev/orespawn/EventHandlers.java
@@ -3,33 +3,42 @@ package com.mcmoddev.orespawn;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Random;
+import java.util.Set;
 
-import com.mcmoddev.orespawn.api.DimensionLogic;
 import com.mcmoddev.orespawn.api.OreSpawnAPI;
 import com.mcmoddev.orespawn.api.SpawnEntry;
 import com.mcmoddev.orespawn.api.SpawnLogic;
 import com.mcmoddev.orespawn.data.Config;
 import com.mcmoddev.orespawn.data.Constants;
-import com.mcmoddev.orespawn.data.DefaultOregenParameters;
 
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.nbt.NBTTagString;
-import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.World;
-import net.minecraft.world.biome.Biome;
 import net.minecraft.world.chunk.IChunkGenerator;
 import net.minecraft.world.chunk.IChunkProvider;
+import net.minecraft.world.gen.ChunkProviderServer;
 import net.minecraftforge.event.terraingen.OreGenEvent;
 import net.minecraftforge.event.world.ChunkDataEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.registry.GameRegistry;
+import net.minecraftforge.fml.common.IWorldGenerator;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import net.minecraftforge.fml.common.eventhandler.Event;
 
 public class EventHandlers {
+	private List<ChunkPos> chunks;
 	
+    public EventHandlers() {
+    	chunks = new ArrayList<>();
+    }
+
     @SubscribeEvent
     public void onGenerateMinable(OreGenEvent.GenerateMinable event) {
         event.setResult(Event.Result.DENY);
@@ -65,43 +74,40 @@ public class EventHandlers {
 	
 	@SubscribeEvent
 	public void onChunkLoad(ChunkDataEvent.Load ev) {
+		World world = ev.getWorld();
+		ChunkPos chunkCoords = new ChunkPos(ev.getChunk().x, ev.getChunk().z);
+		int chunkX = ev.getChunk().x;
+		int chunkZ = ev.getChunk().z;
+		
+		if( chunks.contains(chunkCoords) ) {
+			return;
+		}
+		
 		if( Config.getBoolean(Constants.RETROGEN_KEY) ) {
+            chunks.add(chunkCoords);
+	        Set<IWorldGenerator> worldGens = ObfuscationReflectionHelper.getPrivateValue(GameRegistry.class, null, "worldGenerators");
 			NBTTagCompound chunkTag = ev.getData().getCompoundTag(Constants.CHUNK_TAG_NAME);
 			int count = chunkTag==null?0:chunkTag.getTagList(Constants.ORE_TAG, 8).tagCount();
 			if( count != countOres(ev.getWorld().provider.getDimension()) ||
 					Config.getBoolean(Constants.FORCE_RETROGEN_KEY)) {
-				doRegen(ev.getWorld(), ev.getChunk().x, ev.getChunk().z);
+                for (Iterator<IWorldGenerator> iterator = worldGens.iterator(); iterator.hasNext();)
+                {
+                    IWorldGenerator wg = iterator.next();
+                    long worldSeed = world.getSeed();
+                    Random fmlRandom = new Random(worldSeed);
+                    long xSeed = fmlRandom.nextLong() >> 2 + 1L;
+                    long zSeed = fmlRandom.nextLong() >> 2 + 1L;
+                    long chunkSeed = (xSeed * chunkCoords.x + zSeed * chunkCoords.z) ^ worldSeed;
+
+                    fmlRandom.setSeed(chunkSeed);
+                    ChunkProviderServer chunkProvider = (ChunkProviderServer) world.getChunkProvider();
+                    IChunkGenerator chunkGenerator = ObfuscationReflectionHelper.getPrivateValue(ChunkProviderServer.class, chunkProvider, "field_186029_c", "chunkGenerator");
+                    wg.generate(fmlRandom, chunkX, chunkZ, world, chunkGenerator, chunkProvider);
+                }
 			}
 		}
 	}
 
-	private void doRegen( World w, int chunkX, int chunkZ ) {
-		IChunkProvider prov = w.getChunkProvider();
-		IChunkGenerator gen = w.provider.createChunkGenerator();
-		Random rand = w.rand;
-		
-		List<SpawnEntry> spawns = new ArrayList<>();
-		for( SpawnLogic sL : OreSpawn.API.getAllSpawnLogic().values() ) {
-			DimensionLogic dLM = sL.getDimension(w.provider.getDimension());
-			DimensionLogic dLW = sL.getDimension(OreSpawnAPI.DIMENSION_WILDCARD);
-			
-			spawns.addAll(dLM.getEntries());
-			if( !dLW.getEntries().isEmpty() ) {
-				spawns.addAll(dLW.getEntries());
-			}
-		}
-		for( SpawnEntry sE : spawns ) {
-			Biome biome = w.getBiomeProvider().getBiome(new BlockPos(chunkX*16, 64,chunkZ*16));
-			if( sE.getBiomes().contains(biome) || sE.getBiomes() == Collections.EMPTY_LIST || sE.getBiomes().size() == 0 ) {
-				retrogen(rand, chunkX, chunkZ, w, prov, gen, sE);
-			}
-		}
-	}
-	
-	private void retrogen(Random rand, int chunkX, int chunkZ, World world, IChunkProvider prov, IChunkGenerator gen, SpawnEntry s) {
-		DefaultOregenParameters p = new DefaultOregenParameters(s);
-		s.getFeatureGen().generate(rand, chunkX, chunkZ, world, gen, prov, p);
-	}
 
 	private int countOres(int dim) {
 		int acc = 0;

--- a/src/main/java/com/mcmoddev/orespawn/EventHandlers.java
+++ b/src/main/java/com/mcmoddev/orespawn/EventHandlers.java
@@ -23,11 +23,18 @@ import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.chunk.IChunkGenerator;
 import net.minecraft.world.chunk.IChunkProvider;
+import net.minecraftforge.event.terraingen.OreGenEvent;
 import net.minecraftforge.event.world.ChunkDataEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.eventhandler.Event;
 
 public class EventHandlers {
-
+	
+    @SubscribeEvent
+    public void onGenerateMinable(OreGenEvent.GenerateMinable event) {
+        event.setResult(Event.Result.DENY);
+    }
+    
 	@SubscribeEvent
 	public void onChunkSave(ChunkDataEvent.Save ev) {
 		NBTTagCompound dataTag = ev.getData().getCompoundTag(Constants.CHUNK_TAG_NAME);

--- a/src/main/java/com/mcmoddev/orespawn/OreSpawn.java
+++ b/src/main/java/com/mcmoddev/orespawn/OreSpawn.java
@@ -60,6 +60,10 @@ public class OreSpawn {
     		MinecraftForge.EVENT_BUS.register(eventHandlers);
     	}
     	
+    	if( Config.getBoolean(Constants.REPLACE_VANILLA_OREGEN) ) {
+    		MinecraftForge.ORE_GEN_BUS.register(eventHandlers);
+    	}
+    	
     	OS1Reader.loadEntries(Paths.get(ev.getSuggestedConfigurationFile().toPath().getParent().toString(),"orespawn"));
     	OS2Reader.loadEntries();
 

--- a/src/main/java/com/mcmoddev/orespawn/data/Config.java
+++ b/src/main/java/com/mcmoddev/orespawn/data/Config.java
@@ -19,8 +19,10 @@ public class Config {
 		// Load our Boolean Values
 		boolVals.put(Constants.RETROGEN_KEY, configuration.getBoolean(Constants.RETROGEN_KEY, Configuration.CATEGORY_GENERAL, false, "Do we have Retrogen active and generating anything different from the last run in already existing chunks ?"));
 		boolVals.put(Constants.FORCE_RETROGEN_KEY, configuration.getBoolean(Constants.FORCE_RETROGEN_KEY, Configuration.CATEGORY_GENERAL, false, "Force all chunks to retrogen regardless of anything else"));
+		boolVals.put(Constants.REPLACE_VANILLA_OREGEN,  configuration.getBoolean(Constants.REPLACE_VANILLA_OREGEN, Configuration.CATEGORY_GENERAL, false, "Replace vanilla ore-generation entirely"));
 		knownKeys.add(Constants.RETROGEN_KEY);
 		knownKeys.add(Constants.FORCE_RETROGEN_KEY);
+		knownKeys.add(Constants.REPLACE_VANILLA_OREGEN);
 	}
 	
 	public static boolean getBoolean(String keyname) {

--- a/src/main/java/com/mcmoddev/orespawn/data/Config.java
+++ b/src/main/java/com/mcmoddev/orespawn/data/Config.java
@@ -27,9 +27,9 @@ public class Config {
 	
 	public static boolean getBoolean(String keyname) {
 		if( knownKeys.contains(keyname) && boolVals.containsKey(keyname) ) {
-			if(keyname.equals(Constants.RETROGEN_KEY) || keyname.equals(Constants.FORCE_RETROGEN_KEY)) {
-				return false;
-			}
+//			if(keyname.equals(Constants.RETROGEN_KEY) || keyname.equals(Constants.FORCE_RETROGEN_KEY)) {
+//				return false;
+//			}
 			return boolVals.get(keyname);
 		}
 		return false;

--- a/src/main/java/com/mcmoddev/orespawn/data/Constants.java
+++ b/src/main/java/com/mcmoddev/orespawn/data/Constants.java
@@ -10,4 +10,5 @@ public class Constants {
 	public static final String CHUNK_TAG_NAME = "MMD OreSpawn Data";
 	public static final String ORE_TAG = "ores";
 	public static final String FEATURES_TAG = "features";
+	public static final String REPLACE_VANILLA_OREGEN = "Replace Vanilla Oregen";
 }

--- a/src/main/java/com/mcmoddev/orespawn/impl/OreSpawnImpl.java
+++ b/src/main/java/com/mcmoddev/orespawn/impl/OreSpawnImpl.java
@@ -39,9 +39,9 @@ public class OreSpawnImpl implements OreSpawnAPI {
         Random random = new Random();
 
         worldGenerator = new OreSpawnWorldGen(spawnLogic.getAllDimensions(), random.nextLong());
-        if (!Config.getBoolean(Constants.RETROGEN_KEY)) {
+        //if (!Config.getBoolean(Constants.RETROGEN_KEY)) {
         	GameRegistry.registerWorldGenerator(worldGenerator, 100);
-        }
+        //}
         
         OreSpawn.LOGGER.info("Registered spawn logic for mod " + id);
     }

--- a/src/main/java/com/mcmoddev/orespawn/worldgen/OreSpawnWorldGen.java
+++ b/src/main/java/com/mcmoddev/orespawn/worldgen/OreSpawnWorldGen.java
@@ -49,16 +49,28 @@ public class OreSpawnWorldGen implements IWorldGenerator {
 
 		int thisDim = world.provider.getDimension();
 		DimensionLogic dimensionLogic = this.dimensions.get(thisDim);
-
+		List<SpawnEntry> entries = new ArrayList<>();
+		
 		if( dimensionLogic == null ) {
+			// no logic for this dimension, if this is nether or end, just exit
+			if( thisDim == -1 || thisDim == 1 ) {
+				return;
+			}
+
 			dimensionLogic = this.dimensions.get(OreSpawnAPI.DIMENSION_WILDCARD);
 			if( dimensionLogic == null ) {
 				OreSpawn.LOGGER.fatal("no logic for dimension "+thisDim+" or for all dimensions");
 				return;
 			}
+			entries.addAll(dimensionLogic.getEntries());
+		} else if( thisDim != -1 && thisDim != 1 ) {
+			dimensionLogic = this.dimensions.get(OreSpawnAPI.DIMENSION_WILDCARD);
+			if( dimensionLogic != null ) {
+				entries.addAll(dimensionLogic.getEntries());
+			}
 		}
 
-		for( SpawnEntry sE : dimensionLogic.getEntries() ) {
+		for( SpawnEntry sE : entries ) {
 			Biome biome = world.getBiomeProvider().getBiome(new BlockPos(chunkX*16, 64,chunkZ*16));
 			//			OreSpawn.LOGGER.fatal("Trying to generate in biome "+biome+" for spawn entry with block of type "+sE.getState());
 			if( sE.getBiomes().contains(biome) || sE.getBiomes() == Collections.EMPTY_LIST || sE.getBiomes().size() == 0 ) {


### PR DESCRIPTION
The commits in this PR should bring full feature parity with OreSpawn 2 and fix the issue where Spawns specified with the wildcard value were spawning in the Nether and the End. The fix used is not optimal, but will likely remain as spawns in those two dimensions are rather specific.