### PR TITLE
Move JSON load to Init-Phase

### DIFF
--- a/src/main/java/com/mcmoddev/orespawn/OreSpawn.java
+++ b/src/main/java/com/mcmoddev/orespawn/OreSpawn.java
@@ -52,6 +52,7 @@ public class OreSpawn {
     public static final OS3Writer writer = new OS3Writer();
     public static final EventHandlers eventHandlers = new EventHandlers();
     public static final FeatureRegistry FEATURES = new FeatureRegistry();
+    public static String OS1ConfigPath;
     
     @EventHandler
     public void preInit(FMLPreInitializationEvent ev) {
@@ -65,16 +66,15 @@ public class OreSpawn {
     		MinecraftForge.ORE_GEN_BUS.register(eventHandlers);
     	}
     	
-    	OS1Reader.loadEntries(Paths.get(ev.getSuggestedConfigurationFile().toPath().getParent().toString(),"orespawn"));
-    	OS2Reader.loadEntries();
-    	OS3Reader.loadEntries();
-    	
+    	OS1ConfigPath = Paths.get(ev.getSuggestedConfigurationFile().toPath().getParent().toString(),"orespawn").toString();
     	FMLInterModComms.sendFunctionMessage("orespawn", "api", "com.mcmoddev.orespawn.data.VanillaOrespawn");
     }
 
     @EventHandler
     public void init(FMLInitializationEvent ev) {
-    	// nothing to do here, yet
+    	OS1Reader.loadEntries(Paths.get(OS1ConfigPath));
+    	OS2Reader.loadEntries();
+    	OS3Reader.loadEntries();
     }
 
     @EventHandler


### PR DESCRIPTION
As noted in Issue #17 and issue #21 doing all loading and processing in the PreInitialization phase leads to issues where we cannot find specified blocks because they have not been registered yet thanks to OreSpawn being run before the mod that provides them.

Moving the loading of the Json's to the Initialization phase should resolve #21 entirely and also provide a resolution to item 2 on the list of suggestions for #17 (though we still have documentation to write for the IFeature interface, among other bits, before that set of issues/suggestions is fully handled)