### PR TITLE
Logic Bombs

### DIFF
--- a/src/main/java/com/mcmoddev/orespawn/OreSpawn.java
+++ b/src/main/java/com/mcmoddev/orespawn/OreSpawn.java
@@ -8,6 +8,7 @@ import com.mcmoddev.orespawn.json.OS2Reader;
 import com.mcmoddev.orespawn.json.OS3Reader;
 import com.mcmoddev.orespawn.json.OS3Writer;
 import com.mcmoddev.orespawn.api.OreSpawnAPI;
+import com.mcmoddev.orespawn.api.SpawnEntry;
 import com.mcmoddev.orespawn.commands.AddOreCommand;
 import com.mcmoddev.orespawn.commands.ClearChunkCommand;
 import com.mcmoddev.orespawn.commands.DumpBiomesCommand;
@@ -15,6 +16,10 @@ import com.mcmoddev.orespawn.data.Config;
 import com.mcmoddev.orespawn.api.SpawnLogic;
 
 import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
@@ -52,7 +57,8 @@ public class OreSpawn {
     public static final OS3Writer writer = new OS3Writer();
     public static final EventHandlers eventHandlers = new EventHandlers();
     public static final FeatureRegistry FEATURES = new FeatureRegistry();
-    public static String OS1ConfigPath;
+    private String OS1ConfigPath;
+    public static final Map<Integer, List<SpawnEntry>> spawns = new HashMap<>();
     
     @EventHandler
     public void preInit(FMLPreInitializationEvent ev) {
@@ -66,7 +72,7 @@ public class OreSpawn {
     		MinecraftForge.ORE_GEN_BUS.register(eventHandlers);
     	}
     	
-    	OS1ConfigPath = Paths.get(ev.getSuggestedConfigurationFile().toPath().getParent().toString(),"orespawn").toString();
+    	this.OS1ConfigPath = Paths.get(ev.getSuggestedConfigurationFile().toPath().getParent().toString(),"orespawn").toString();
     	FMLInterModComms.sendFunctionMessage("orespawn", "api", "com.mcmoddev.orespawn.data.VanillaOrespawn");
     }
 
@@ -75,6 +81,7 @@ public class OreSpawn {
     	OS1Reader.loadEntries(Paths.get(OS1ConfigPath));
     	OS2Reader.loadEntries();
     	OS3Reader.loadEntries();
+    	API.registerSpawns();
     }
 
     @EventHandler

--- a/src/main/java/com/mcmoddev/orespawn/api/OreSpawnAPI.java
+++ b/src/main/java/com/mcmoddev/orespawn/api/OreSpawnAPI.java
@@ -3,6 +3,7 @@ package com.mcmoddev.orespawn.api;
 import java.util.Map;
 
 import com.mcmoddev.orespawn.api.SpawnLogic;
+import com.mcmoddev.orespawn.worldgen.OreSpawnWorldGen;
 
 public interface OreSpawnAPI {
     int DIMENSION_WILDCARD = "DIMENSION_WILDCARD".hashCode();
@@ -14,4 +15,8 @@ public interface OreSpawnAPI {
     Map<String, SpawnLogic> getAllSpawnLogic();
     
     void registerSpawnLogic(String name, SpawnLogic logic);
+    
+    OreSpawnWorldGen getWorldGenerator();
+    
+    void registerSpawns();
 }

--- a/src/main/java/com/mcmoddev/orespawn/data/ReplacementsRegistry.java
+++ b/src/main/java/com/mcmoddev/orespawn/data/ReplacementsRegistry.java
@@ -19,7 +19,7 @@ public class ReplacementsRegistry {
 	
 	public static IBlockState getDimensionDefault(int dimension) {
 		String[] names = { "minecraft:netherrack", "minecraft:stone", "minecraft:end_stone" };
-		if( dimension < 0 || dimension > 1 ) {
+		if( dimension < -1 || dimension > 1 ) {
 			return ForgeRegistries.BLOCKS.getValue(new ResourceLocation(names[1])).getDefaultState();			
 		}
 		return ForgeRegistries.BLOCKS.getValue(new ResourceLocation(names[dimension+1])).getDefaultState();

--- a/src/main/java/com/mcmoddev/orespawn/impl/OreSpawnImpl.java
+++ b/src/main/java/com/mcmoddev/orespawn/impl/OreSpawnImpl.java
@@ -1,6 +1,7 @@
 package com.mcmoddev.orespawn.impl;
 
 import com.google.common.collect.ImmutableMap;
+import com.mcmoddev.orespawn.api.DimensionLogic;
 import com.mcmoddev.orespawn.api.OreSpawnAPI;
 import com.mcmoddev.orespawn.api.SpawnLogic;
 
@@ -9,6 +10,7 @@ import com.mcmoddev.orespawn.worldgen.OreSpawnWorldGen;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 
 import java.util.*;
+import java.util.Map.Entry;
 
 public class OreSpawnImpl implements OreSpawnAPI {
     private final Map<String, SpawnLogic> spawnLogic = new HashMap<>();
@@ -31,17 +33,31 @@ public class OreSpawnImpl implements OreSpawnAPI {
 
     public void registerSpawnLogic(String id, SpawnLogic spawnLogic) {
         this.spawnLogic.put(id, spawnLogic);
-
-        Random random = new Random();
-
-        worldGenerator = new OreSpawnWorldGen(spawnLogic.getAllDimensions(), random.nextLong());
-        //if (!Config.getBoolean(Constants.RETROGEN_KEY)) {
-        	GameRegistry.registerWorldGenerator(worldGenerator, 100);
-        //}
-        
-        OreSpawn.LOGGER.info("Registered spawn logic for mod " + id);
     }
 
+    public void registerSpawns() {
+    	// build a proper tracking of data for the spawner
+    	for( Entry<String, SpawnLogic> ent : spawnLogic.entrySet() ) {
+    		for( Entry<Integer, DimensionLogic> dL : ent.getValue().getAllDimensions().entrySet()) {
+				if( OreSpawn.spawns.containsKey(dL.getKey()) ) {
+					OreSpawn.spawns.get(dL.getKey()).addAll(dL.getValue().getEntries());
+				} else {
+					OreSpawn.spawns.put(dL.getKey(), new ArrayList<>());
+					OreSpawn.spawns.get(dL.getKey()).addAll(dL.getValue().getEntries());
+				}
+    		}
+        	OreSpawn.LOGGER.info("Registered spawn logic for mod " + ent.getKey());
+    	}
+    	
+    	Random random = new Random();
+   
+    	worldGenerator = new OreSpawnWorldGen(OreSpawn.spawns, random.nextLong());
+    	//if (!Config.getBoolean(Constants.RETROGEN_KEY)) {
+    	GameRegistry.registerWorldGenerator(worldGenerator, 100);
+    	//}
+            
+    }
+    
     public OreSpawnWorldGen getWorldGenerator() {
         return worldGenerator;
     }

--- a/src/main/java/com/mcmoddev/orespawn/impl/features/DefaultFeatureGenerator.java
+++ b/src/main/java/com/mcmoddev/orespawn/impl/features/DefaultFeatureGenerator.java
@@ -105,7 +105,6 @@ public class DefaultFeatureGenerator implements IFeature {
 
 	public static void spawnOre( BlockPos blockPos, IBlockState oreBlock, int quantity, World world, Random prng, IBlockState replaceBlock) {
 		int count = quantity;
-//		OreSpawn.LOGGER.fatal("Spawning block of "+oreBlock+" at "+blockPos+" with quantity "+quantity);
 		if(quantity <= 8){
 			int[] scrambledLUT = new int[offsetIndexRef_small.length];
 			System.arraycopy(offsetIndexRef_small, 0, scrambledLUT, 0, scrambledLUT.length);
@@ -182,7 +181,6 @@ public class DefaultFeatureGenerator implements IFeature {
 	}
 	
 	private static void spawn(IBlockState b, World w, BlockPos coord, int dimension, boolean cacheOverflow, IBlockState replaceBlock){
-		//OreSpawn.LOGGER.fatal("!!!! Trying to spawn block at "+coord+" of type "+b.getBlock());
 		IBlockState b2r = replaceBlock;
 		if(b2r == null) {
 			b2r = ReplacementsRegistry.getDimensionDefault(w.provider.getDimension());


### PR DESCRIPTION
Turns out that moving the JSON loading to a different phase caused all kinds of issues in how things were being done, causing the generation code to not, really, work.

This fixes that mistake by changing some book-keeping and moving some bits around internally - incidentally also making it so we only ever register a single IWorldGenerator.

On top of that the ReplacementsRegistry code contained a logic error that would stop it from ever returning the proper default for the Nether. This has also been fixed - NetherMetals now integrates and works properly.

