### PR TITLE
didn't notice it until I added ModernMetals, but there is a logic bug…

### DIFF
--- a/src/main/java/com/mcmoddev/orespawn/worldgen/OreSpawnWorldGen.java
+++ b/src/main/java/com/mcmoddev/orespawn/worldgen/OreSpawnWorldGen.java
@@ -71,7 +71,7 @@ public class OreSpawnWorldGen implements IWorldGenerator {
 
 		for( SpawnBuilder sE : entries ) {
 			Biome biome = world.getBiomeProvider().getBiome(new BlockPos(chunkX*16, 64,chunkZ*16));
-			if( sE.getBiomes().matches(biome)) {
+			if( sE.getBiomes().matches(biome) || sE.getBiomes().getBiomes().size() == 0 ) {
 				IFeature currentFeatureGen = sE.getFeatureGen().getGenerator();
 				IBlockState replacement = sE.getReplacementBlocks().get(0);
 				if( replacement == null ) {


### PR DESCRIPTION
… in that an empty BiomeLocation returns false when it should probably return true