### PR TITLE
Fix a logic bug

### DIFF
--- a/src/main/java/com/mcmoddev/orespawn/api/plugin/PluginLoader.java
+++ b/src/main/java/com/mcmoddev/orespawn/api/plugin/PluginLoader.java
@@ -108,15 +108,11 @@ public enum PluginLoader {
 					InputStream reader = null;
 					Path target = Paths.get(".","orespawn","os3",String.format("%s.json", pd.modId));
 					tName = String.format("%s.json", pd.modId);
-					if( target.toFile().exists() ) {
-						// the file we were going to copy out to already exists!
-						walk.close();
-						return;
+					if( !target.toFile().exists() ) {
+						reader = Files.newInputStream(p);
+						FileUtils.copyInputStreamToFile(reader, target.toFile());
+						IOUtils.closeQuietly(reader);
 					}
-
-					reader = Files.newInputStream(p);
-					FileUtils.copyInputStreamToFile(reader, target.toFile());
-					IOUtils.closeQuietly(reader);
 				}
 			}
 			walk.close();

--- a/src/main/java/com/mcmoddev/orespawn/impl/os3/SpawnBuilderImpl.java
+++ b/src/main/java/com/mcmoddev/orespawn/impl/os3/SpawnBuilderImpl.java
@@ -32,10 +32,12 @@ public class SpawnBuilderImpl implements SpawnBuilder {
 	@Override
 	public FeatureBuilder newFeatureBuilder(@Nullable String featureName) {
 		this.featureGen = new FeatureBuilderImpl();
-		if( OreSpawn.FEATURES.getFeature(featureName) != null ) {
-			this.featureGen.setGenerator(featureName);
+		if( OreSpawn.FEATURES.getFeature(featureName) == null ) {
+			this.featureGen.setGenerator("default");
+			return this.featureGen;
 		}
 		
+		this.featureGen.setGenerator(featureName);
 		return this.featureGen;
 	}
 


### PR DESCRIPTION
In scanResources() it would stop scanning the first time it found a file that already existed in the target directory. Since this system isn't limited to just one file provided per mod, that is not a good tactic and it should make sure that all provided files are copied over.