### PR TITLE
Os3.2work

### DIFF
--- a/src/main/java/com/mcmoddev/orespawn/api/IFeature.java
+++ b/src/main/java/com/mcmoddev/orespawn/api/IFeature.java
@@ -3,6 +3,7 @@ package com.mcmoddev.orespawn.api;
 import java.util.Random;
 
 import com.google.gson.JsonObject;
+import com.mcmoddev.orespawn.util.BinaryTree;
 
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.math.ChunkPos;
@@ -12,7 +13,7 @@ import net.minecraft.world.chunk.IChunkProvider;
 
 public interface IFeature {
 	void generate(ChunkPos pos, World world, IChunkGenerator chunkGenerator,
-			IChunkProvider chunkProvider, JsonObject parameters, IBlockState block, IBlockState blockReplace );
+			IChunkProvider chunkProvider, JsonObject parameters, BinaryTree ores, IBlockState blockReplace );
 	
 	void setRandom(Random rand);
 	

--- a/src/main/java/com/mcmoddev/orespawn/api/os3/SpawnBuilder.java
+++ b/src/main/java/com/mcmoddev/orespawn/api/os3/SpawnBuilder.java
@@ -7,6 +7,7 @@ import javax.annotation.Nullable;
 
 import com.google.common.collect.ImmutableList;
 import com.mcmoddev.orespawn.api.BiomeLocation;
+import com.mcmoddev.orespawn.util.BinaryTree;
 
 import net.minecraft.block.state.IBlockState;
 
@@ -21,4 +22,7 @@ public interface SpawnBuilder {
 	ImmutableList<OreBuilder> getOres();
 	ImmutableList<IBlockState> getReplacementBlocks();
 	FeatureBuilder getFeatureGen();
+	
+	// added for OreSpawn 3.2 and version 1.2 of the config
+	BinaryTree getOreSpawns();
 }

--- a/src/main/java/com/mcmoddev/orespawn/api/plugin/PluginLoader.java
+++ b/src/main/java/com/mcmoddev/orespawn/api/plugin/PluginLoader.java
@@ -106,7 +106,7 @@ public enum PluginLoader {
 
 				if( "json".equals(FilenameUtils.getExtension(name)) ) {
 					InputStream reader = null;
-					Path target = Paths.get(".","orespawn","os3",String.format("%s.json", pd.modId));
+					Path target = Paths.get(".", "config","orespawn","os3",String.format("%s.json", pd.modId));
 					tName = String.format("%s.json", pd.modId);
 					if( !target.toFile().exists() ) {
 						reader = Files.newInputStream(p);

--- a/src/main/java/com/mcmoddev/orespawn/api/plugin/PluginLoader.java
+++ b/src/main/java/com/mcmoddev/orespawn/api/plugin/PluginLoader.java
@@ -106,7 +106,7 @@ public enum PluginLoader {
 
 				if( "json".equals(FilenameUtils.getExtension(name)) ) {
 					InputStream reader = null;
-					Path target = Paths.get(".", "config","orespawn","os3",String.format("%s.json", pd.modId));
+					Path target = Paths.get(".", "config","orespawn3",String.format("%s.json", pd.modId));
 					tName = String.format("%s.json", pd.modId);
 					if( !target.toFile().exists() ) {
 						reader = Files.newInputStream(p);

--- a/src/main/java/com/mcmoddev/orespawn/commands/DumpBiomesCommand.java
+++ b/src/main/java/com/mcmoddev/orespawn/commands/DumpBiomesCommand.java
@@ -12,9 +12,9 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraft.world.biome.Biome;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
-import org.apache.commons.io.Charsets;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.codec.CharEncoding;
 
 import java.io.File;
 import java.io.IOException;
@@ -42,7 +42,7 @@ public class DumpBiomesCommand extends CommandBase {
         String json = gson.toJson(array);
 
         try {
-            FileUtils.writeStringToFile(new File(".", "biome_dump.json"), StringEscapeUtils.unescapeJson(json), Charsets.UTF_8);
+            FileUtils.writeStringToFile(new File(".", "biome_dump.json"), StringEscapeUtils.unescapeJson(json), CharEncoding.UTF_8);
         } catch (IOException e) {
             throw new CommandException("Failed to save the json file");
         }

--- a/src/main/java/com/mcmoddev/orespawn/data/Constants.java
+++ b/src/main/java/com/mcmoddev/orespawn/data/Constants.java
@@ -3,7 +3,7 @@ package com.mcmoddev.orespawn.data;
 public class Constants {
 	public static final String MODID = "orespawn";
 	public static final String NAME = "MMD OreSpawn";
-	public static final String VERSION = "3.1.0";
+	public static final String VERSION = "3.2.0";
 	public static final String RETROGEN_KEY = "Retrogen";
 	public static final String CONFIG_FILE = "config/orespawn.cfg";
 	public static final String FORCE_RETROGEN_KEY = "Force Retrogen";

--- a/src/main/java/com/mcmoddev/orespawn/data/FeatureRegistry.java
+++ b/src/main/java/com/mcmoddev/orespawn/data/FeatureRegistry.java
@@ -3,14 +3,15 @@ package com.mcmoddev.orespawn.data;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
+import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.apache.commons.io.Charsets;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.codec.CharEncoding;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -104,7 +105,7 @@ public class FeatureRegistry {
 		String rawJson = "[]";
 		JsonArray elements;
 		try {
-			rawJson = FileUtils.readFileToString(file);
+			rawJson = FileUtils.readFileToString(file, Charset.defaultCharset());
 		} catch(IOException e) {
 			CrashReport report = CrashReport.makeCrashReport(e, "Failed reading config " + file.getName());
 			report.getCategory().addCrashSection(ORE_SPAWN_VERSION, Constants.VERSION);
@@ -135,7 +136,7 @@ public class FeatureRegistry {
 
 		String json = gson.toJson(root);
         try {
-            FileUtils.writeStringToFile(file, StringEscapeUtils.unescapeJson(json), Charsets.UTF_8);
+            FileUtils.writeStringToFile(file, StringEscapeUtils.unescapeJson(json), CharEncoding.UTF_8);
         } catch (IOException e) {
 			CrashReport report = CrashReport.makeCrashReport(e, "Failed writing config " + file.getName());
 			report.getCategory().addCrashSection(ORE_SPAWN_VERSION, Constants.VERSION);

--- a/src/main/java/com/mcmoddev/orespawn/impl/os3/SpawnBuilderImpl.java
+++ b/src/main/java/com/mcmoddev/orespawn/impl/os3/SpawnBuilderImpl.java
@@ -9,6 +9,7 @@ import com.google.common.collect.ImmutableList;
 import com.mcmoddev.orespawn.OreSpawn;
 import com.mcmoddev.orespawn.api.BiomeLocation;
 import com.mcmoddev.orespawn.api.os3.SpawnBuilder;
+import com.mcmoddev.orespawn.util.BinaryTree;
 
 import net.minecraft.block.state.IBlockState;
 
@@ -21,6 +22,7 @@ public class SpawnBuilderImpl implements SpawnBuilder {
 	private FeatureBuilder featureGen;
 	private List<IBlockState> replacementBlocks;
 	private List<OreBuilder> myOres;
+	private BinaryTree oreSpawns;
 
 	public SpawnBuilderImpl() {
 		this.biomeLocs = null;
@@ -59,14 +61,9 @@ public class SpawnBuilderImpl implements SpawnBuilder {
 		this.biomeLocs = biomes.getBiomes();
 		this.featureGen = feature;
 		this.replacementBlocks.addAll(replacements);
-		int oc = (int)(100.0f / ((float)ores.length));
 		if( ores.length > 1 ) {
 			for(int i = 0; i < ores.length; i++) {
-				OreBuilder current = ores[i];
-				if( current.getChance() == 100 ) { 
-					current.setChance(oc);
-				}
-				this.myOres.add(current);
+				this.myOres.add(ores[i]);
 			}
 		} else {
 			this.myOres.add(ores[0]);
@@ -92,6 +89,30 @@ public class SpawnBuilderImpl implements SpawnBuilder {
 	@Override
 	public FeatureBuilder getFeatureGen() {
 		return this.featureGen;
+	}
+
+	@Override
+	public BinaryTree getOreSpawns() {
+		if( this.oreSpawns == null ) {
+			this.buildOreSpawnTree();
+		}
+		
+		return this.oreSpawns;
+	}
+
+	private void buildOreSpawnTree() {
+		int maxVal = 0;
+		for( OreBuilder os : this.myOres ) {
+			maxVal += os.getChance();
+		}
+		
+		int median = maxVal / 2;
+		int count = 0;
+		this.oreSpawns = new BinaryTree(median);
+		for( OreBuilder os : this.myOres ) {
+			count += os.getChance();
+			this.oreSpawns.addNode(os, count);
+		}
 	}
 
 }

--- a/src/main/java/com/mcmoddev/orespawn/impl/os3/SpawnBuilderImpl.java
+++ b/src/main/java/com/mcmoddev/orespawn/impl/os3/SpawnBuilderImpl.java
@@ -101,18 +101,22 @@ public class SpawnBuilderImpl implements SpawnBuilder {
 	}
 
 	private void buildOreSpawnTree() {
-		int maxVal = 0;
-		for( OreBuilder os : this.myOres ) {
-			maxVal += os.getChance();
-		}
-		
-		int median = maxVal / 2;
-		int count = 0;
-		this.oreSpawns = new BinaryTree(median);
-		for( OreBuilder os : this.myOres ) {
-			count += os.getChance();
-			this.oreSpawns.addNode(os, count);
+		if( this.myOres.size() > 1 ) {
+			int maxVal = 0;
+			for( OreBuilder os : this.myOres ) {
+				maxVal += os.getChance();
+			}
+
+			int median = maxVal / 2;
+			int count = 0;
+			this.oreSpawns = new BinaryTree(median);
+			for( OreBuilder os : this.myOres ) {
+				count += os.getChance();
+				this.oreSpawns.addNode(os, count);
+			}
+		} else {
+			this.oreSpawns = new BinaryTree(50);
+			this.oreSpawns.makeRoot(this.myOres.get(0));
 		}
 	}
-
 }

--- a/src/main/java/com/mcmoddev/orespawn/json/OS1Reader.java
+++ b/src/main/java/com/mcmoddev/orespawn/json/OS1Reader.java
@@ -1,6 +1,7 @@
 package com.mcmoddev.orespawn.json;
 
 import java.io.File;
+import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -59,7 +60,7 @@ public class OS1Reader {
 		Arrays.stream(files).filter(file -> file.getName().endsWith(".json")).forEach(
 				file -> {
 					try {
-						JsonObject root = parser.parse(FileUtils.readFileToString(file)).getAsJsonObject();
+						JsonObject root = parser.parse(FileUtils.readFileToString(file, Charset.defaultCharset())).getAsJsonObject();
 						
 						BuilderLogic logic = OreSpawn.API.getLogic(FilenameUtils.getBaseName(file.getName()));
 						List<DimensionBuilder> builders = new ArrayList<>();

--- a/src/main/java/com/mcmoddev/orespawn/json/OS2Reader.java
+++ b/src/main/java/com/mcmoddev/orespawn/json/OS2Reader.java
@@ -1,6 +1,7 @@
 package com.mcmoddev.orespawn.json;
 
 import java.io.File;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -46,7 +47,7 @@ public class OS2Reader {
 		Arrays.stream(files).filter(file -> file.getName().endsWith(".json")).forEach(
 				file -> {
 					try {
-						JsonElement full = parser.parse(FileUtils.readFileToString(file));
+						JsonElement full = parser.parse(FileUtils.readFileToString(file, Charset.defaultCharset()));
 						JsonArray elements = full.getAsJsonArray();
 
 						BuilderLogic logic = OreSpawn.API.getLogic(FilenameUtils.getBaseName(file.getName()));

--- a/src/main/java/com/mcmoddev/orespawn/json/OS3Reader.java
+++ b/src/main/java/com/mcmoddev/orespawn/json/OS3Reader.java
@@ -26,7 +26,7 @@ public class OS3Reader {
 	}
 
 	public static void loadEntries() {
-		File directory = new File("." + File.separator + "orespawn", "os3");
+		File directory = new File("config" + File.separator + "orespawn3", "os3");
 		JsonParser parser = new JsonParser();
 
 		if( !directory.exists() ) {

--- a/src/main/java/com/mcmoddev/orespawn/json/OS3Reader.java
+++ b/src/main/java/com/mcmoddev/orespawn/json/OS3Reader.java
@@ -1,6 +1,7 @@
 package com.mcmoddev.orespawn.json;
 
 import java.io.File;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 
 import org.apache.commons.io.FileUtils;
@@ -56,7 +57,7 @@ public class OS3Reader {
 					}
 
 					try {
-						JsonElement full = parser.parse(FileUtils.readFileToString(file));
+						JsonElement full = parser.parse(FileUtils.readFileToString(file, Charset.defaultCharset()));
 						JsonObject parsed = full.getAsJsonObject();
 
 						IOS3Reader reader = null;

--- a/src/main/java/com/mcmoddev/orespawn/json/OS3Reader.java
+++ b/src/main/java/com/mcmoddev/orespawn/json/OS3Reader.java
@@ -26,7 +26,7 @@ public class OS3Reader {
 	}
 
 	public static void loadEntries() {
-		File directory = new File("config" + File.separator + "orespawn3", "os3");
+		File directory = new File("config","orespawn3");
 		JsonParser parser = new JsonParser();
 
 		if( !directory.exists() ) {

--- a/src/main/java/com/mcmoddev/orespawn/json/OS3Writer.java
+++ b/src/main/java/com/mcmoddev/orespawn/json/OS3Writer.java
@@ -2,6 +2,7 @@ package com.mcmoddev.orespawn.json;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.Map.Entry;
 
 import org.apache.commons.io.FileUtils;
@@ -85,7 +86,7 @@ public class OS3Writer {
 	private void writeFile(File file, JsonObject wrapper) {
 		Gson gson = new GsonBuilder().setPrettyPrinting().create();
 		try {
-			FileUtils.writeStringToFile(file, gson.toJson(wrapper));
+			FileUtils.writeStringToFile(file, gson.toJson(wrapper), Charset.defaultCharset(), false);
 		} catch (IOException e) {
 			CrashReport report = CrashReport.makeCrashReport(e, String.format("Failed in config %s", file.getName()));
 			report.getCategory().addCrashSection("OreSpawn Version", Constants.VERSION);

--- a/src/main/java/com/mcmoddev/orespawn/json/OS3Writer.java
+++ b/src/main/java/com/mcmoddev/orespawn/json/OS3Writer.java
@@ -38,7 +38,7 @@ public class OS3Writer {
 	}
 
 	public void writeSpawnEntries() {
-		String basePath = String.format(".%1$sconfig%1$sorespawn3%1$sos3", File.separator);
+		String basePath = String.format(".%1$sconfig%1$sorespawn3", File.separator);
 		writeFeatures(basePath);
 		writeReplacements(basePath);
 		

--- a/src/main/java/com/mcmoddev/orespawn/json/OS3Writer.java
+++ b/src/main/java/com/mcmoddev/orespawn/json/OS3Writer.java
@@ -38,7 +38,7 @@ public class OS3Writer {
 	}
 
 	public void writeSpawnEntries() {
-		String basePath = String.format(".%sorespawn%sos3", File.separator, File.separator);
+		String basePath = String.format(".%1$sconfig%1$sorespawn3%1$sos3", File.separator);
 		writeFeatures(basePath);
 		writeReplacements(basePath);
 		

--- a/src/main/java/com/mcmoddev/orespawn/json/Replacements.java
+++ b/src/main/java/com/mcmoddev/orespawn/json/Replacements.java
@@ -2,10 +2,11 @@ package com.mcmoddev.orespawn.json;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.apache.commons.io.Charsets;
+import org.apache.commons.codec.CharEncoding;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringEscapeUtils;
 
@@ -32,7 +33,7 @@ public class Replacements {
 		String rawJson = "[]";
 		JsonArray elements;
 		try {
-			rawJson = FileUtils.readFileToString(file);
+			rawJson = FileUtils.readFileToString(file, Charset.defaultCharset());
 		} catch(IOException e) {
 			CrashReport report = CrashReport.makeCrashReport(e, "Failed reading config " + file.getName());
 			report.getCategory().addCrashSection("OreSpawn Version", Constants.VERSION);
@@ -67,7 +68,7 @@ public class Replacements {
             }
     		String json = gson.toJson(root);
             try {
-                FileUtils.writeStringToFile(file, StringEscapeUtils.unescapeJson(json), Charsets.UTF_8);
+                FileUtils.writeStringToFile(file, StringEscapeUtils.unescapeJson(json), CharEncoding.UTF_8);
             } catch (IOException e) {
             	OreSpawn.LOGGER.fatal("Error writing "+file.toString()+" - "+e.getLocalizedMessage());
             }		

--- a/src/main/java/com/mcmoddev/orespawn/json/os3/readers/Helpers.java
+++ b/src/main/java/com/mcmoddev/orespawn/json/os3/readers/Helpers.java
@@ -9,6 +9,7 @@ import com.google.gson.JsonObject;
 import com.mcmoddev.orespawn.api.BiomeLocation;
 import com.mcmoddev.orespawn.api.os3.BiomeBuilder;
 import com.mcmoddev.orespawn.api.os3.OreBuilder;
+import com.mcmoddev.orespawn.api.os3.SpawnBuilder;
 import com.mcmoddev.orespawn.data.ReplacementsRegistry;
 import com.mcmoddev.orespawn.data.Constants.ConfigNames;
 import com.mcmoddev.orespawn.impl.location.BiomeLocationComposition;
@@ -101,6 +102,29 @@ public class Helpers {
 				oreB.setOre(oreName);
 			}
 		}
+	}
+
+	public static OreBuilder parseOreEntry(JsonObject oreSpawn, SpawnBuilder spawn) {
+		String oreName = oreSpawn.get("name").getAsString();
+		boolean hasMeta = oreSpawn.has("metadata");
+		String state = oreSpawn.has("state")?oreSpawn.get("state").getAsString():"";
+		int chance = oreSpawn.has("chance")?oreSpawn.get("chance").getAsInt():Integer.MIN_VALUE;
+		
+		OreBuilder thisOre = spawn.newOreBuilder();
+		
+		if( !"".equals(state) ) {
+			thisOre.setOre( oreName, state );
+		} else if( "".equals(state) && hasMeta ) {
+			thisOre.setOre( oreName, oreSpawn.get("meta").getAsInt() );
+		} else {
+			thisOre.setOre( oreName );
+		}
+		
+		if( chance != Integer.MIN_VALUE ) {
+			thisOre.setChance(chance);
+		}
+		
+		return thisOre;
 	}
 
 }

--- a/src/main/java/com/mcmoddev/orespawn/json/os3/readers/OS3V12Reader.java
+++ b/src/main/java/com/mcmoddev/orespawn/json/os3/readers/OS3V12Reader.java
@@ -75,7 +75,7 @@ public class OS3V12Reader implements IOS3Reader {
 	}
 
 	private void parseOres(JsonObject ore, SpawnBuilder spawn, List<SpawnBuilder> spawns, BiomeBuilder biomes, FeatureBuilder feature, List<IBlockState> repBlock, OreBuilder oreB) {
-		if(ore.has("block")) {
+		if(ore.has("block") && !ore.has("blocks")) {
 			String oreName = ore.get(ConfigNames.BLOCK).getAsString();
 			
 			Helpers.handleState(ore,oreB, oreName);

--- a/src/main/java/com/mcmoddev/orespawn/json/os3/readers/OS3V12Reader.java
+++ b/src/main/java/com/mcmoddev/orespawn/json/os3/readers/OS3V12Reader.java
@@ -1,0 +1,94 @@
+package com.mcmoddev.orespawn.json.os3.readers;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.io.FilenameUtils;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.mcmoddev.orespawn.OreSpawn;
+import com.mcmoddev.orespawn.api.os3.BiomeBuilder;
+import com.mcmoddev.orespawn.api.os3.BuilderLogic;
+import com.mcmoddev.orespawn.api.os3.DimensionBuilder;
+import com.mcmoddev.orespawn.api.os3.FeatureBuilder;
+import com.mcmoddev.orespawn.api.os3.OreBuilder;
+import com.mcmoddev.orespawn.api.os3.SpawnBuilder;
+import com.mcmoddev.orespawn.data.Constants.ConfigNames;
+import com.mcmoddev.orespawn.impl.os3.DimensionBuilderImpl;
+import com.mcmoddev.orespawn.impl.os3.SpawnBuilderImpl;
+import com.mcmoddev.orespawn.json.os3.IOS3Reader;
+
+import net.minecraft.block.state.IBlockState;
+
+public class OS3V12Reader implements IOS3Reader {
+
+	@Override
+	public void parseJson(JsonObject entries, String fileName) {
+		JsonArray elements = entries.get(ConfigNames.DIMENSIONS).getAsJsonArray();
+		
+		BuilderLogic logic = OreSpawn.API.getLogic(FilenameUtils.getBaseName(fileName));
+		List<DimensionBuilder> builders = new ArrayList<>();
+
+		for (JsonElement element : elements ) {
+			JsonObject object = element.getAsJsonObject();
+
+			int dimension = object.has(ConfigNames.DIMENSION) ? object.get(ConfigNames.DIMENSION).getAsInt() : OreSpawn.API.dimensionWildcard();
+			DimensionBuilder builder = logic.newDimensionBuilder(dimension);
+			List<SpawnBuilder> spawns = new ArrayList<>();
+			
+			JsonArray ores = object.get(ConfigNames.ORES).getAsJsonArray();
+
+			for (JsonElement oresEntry : ores) {
+				SpawnBuilder spawn = builder.newSpawnBuilder(null);				
+				JsonObject ore = oresEntry.getAsJsonObject();
+				OreBuilder oreB = spawn.newOreBuilder();				
+				
+				FeatureBuilder feature = spawn.newFeatureBuilder(ore.get(ConfigNames.FEATURE).getAsString());
+				feature.setParameters(ore.get(ConfigNames.PARAMETERS).getAsJsonObject());
+
+				String replaceBase = ore.get(ConfigNames.REPLACEMENT).getAsString();
+				IBlockState blockRep = Helpers.getReplacement(replaceBase, dimension);
+
+				BiomeBuilder biomes = spawn.newBiomeBuilder();
+
+				if (ore.has(ConfigNames.BIOMES)) {
+					biomes.setFromBiomeLocation(Helpers.deserializeBiomeLocationList(ore.get(ConfigNames.BIOMES).getAsJsonArray()));
+				}
+
+				parseOres( ore, spawn, spawns, biomes, feature, Arrays.asList(blockRep), oreB );
+				
+				List<IBlockState> repBlock = new ArrayList<>();
+				repBlock.add(blockRep);
+
+				//unlike others, in v1.2 "block" isn't required, as "blocks" may be specified instead
+			}
+			builder.create(spawns.toArray(new SpawnBuilderImpl[spawns.size()]));
+			builders.add(builder);
+		}
+		
+		logic.create(builders.toArray(new DimensionBuilderImpl[builders.size()]));
+
+		OreSpawn.API.registerLogic(logic);
+	}
+
+	private void parseOres(JsonObject ore, SpawnBuilder spawn, List<SpawnBuilder> spawns, BiomeBuilder biomes, FeatureBuilder feature, List<IBlockState> repBlock, OreBuilder oreB) {
+		if(ore.has("block")) {
+			String oreName = ore.get(ConfigNames.BLOCK).getAsString();
+			
+			Helpers.handleState(ore,oreB, oreName);
+			spawn.create(biomes, feature, repBlock, oreB);
+			spawns.add(spawn);
+		} else if(ore.has("blocks")) {
+			List<OreBuilder> oreSpawns = new ArrayList<>();
+			for( JsonElement oreSpawn : ore.getAsJsonArray("blocks") ) {
+				JsonObject oreObj = oreSpawn.getAsJsonObject();
+				oreSpawns.add( Helpers.parseOreEntry( oreObj, spawn) );
+			}
+			spawn.create(biomes, feature, repBlock, oreSpawns.toArray(new OreBuilder[1]));
+			spawns.add(spawn);
+		}
+	}
+}

--- a/src/main/java/com/mcmoddev/orespawn/util/BinaryTree.java
+++ b/src/main/java/com/mcmoddev/orespawn/util/BinaryTree.java
@@ -1,0 +1,31 @@
+package com.mcmoddev.orespawn.util;
+
+import com.mcmoddev.orespawn.api.os3.OreBuilder;
+
+public class BinaryTree {
+	private TreeNode root;
+	private int maxVal;
+	
+	private BinaryTree() {
+		this.root = new TreeNode();
+	}
+	
+	public BinaryTree(int median) {
+		this();
+		this.maxVal = (median * 2) + 1;
+		this.root.setNodeId(median);
+	}
+	
+	public int getMax() {
+		return this.maxVal;
+	}
+	
+	public OreBuilder findMatchingNode(int value) {
+		TreeNode actualNode = this.root.findNode(value);
+		return actualNode.getValue();
+	}
+	
+	public void addNode(OreBuilder value, int nodeId) {
+		this.root.addNode(value, nodeId);
+	}
+}

--- a/src/main/java/com/mcmoddev/orespawn/util/BinaryTree.java
+++ b/src/main/java/com/mcmoddev/orespawn/util/BinaryTree.java
@@ -28,4 +28,9 @@ public class BinaryTree {
 	public void addNode(OreBuilder value, int nodeId) {
 		this.root.addNode(value, nodeId);
 	}
+
+	public void makeRoot(OreBuilder oreBuilder) {
+		this.root.setValue(oreBuilder);
+		this.root.setNodeId(50);
+	}
 }

--- a/src/main/java/com/mcmoddev/orespawn/util/TreeNode.java
+++ b/src/main/java/com/mcmoddev/orespawn/util/TreeNode.java
@@ -37,6 +37,8 @@ public class TreeNode {
 	}
 
 	public TreeNode findNode(int value) {
+		if( this.left == null && this.right == null ) return this;
+		
 		if( value < this.nodeID ) {
 			return this.findLeft(value);
 		} else if( value > this.nodeID) {

--- a/src/main/java/com/mcmoddev/orespawn/util/TreeNode.java
+++ b/src/main/java/com/mcmoddev/orespawn/util/TreeNode.java
@@ -1,0 +1,107 @@
+package com.mcmoddev.orespawn.util;
+
+import com.mcmoddev.orespawn.OreSpawn;
+import com.mcmoddev.orespawn.api.os3.OreBuilder;
+
+public class TreeNode {
+	private TreeNode parent;
+	private TreeNode left;
+	private TreeNode right;
+	private OreBuilder actualValue;
+	private int nodeID;
+	
+	TreeNode() {
+		this.parent = this.left = this.right = null;
+	}
+	
+	TreeNode(TreeNode parent) {
+		this();
+		this.parent = parent;
+	}
+	
+	public void setNodeId(int value) {
+		if( value > 0 ) {
+			this.nodeID = value;
+		} else if( this.actualValue != null ) {
+			this.nodeID = this.actualValue.getChance();
+		}
+	}
+	
+	public void setValue(OreBuilder value) {
+		this.actualValue = value;
+		this.setNodeId(0);
+	}
+
+	public TreeNode findNode(int value) {
+		if( ( (value < this.nodeID) && (value > this.left.getNodeId()) ) ||
+			( (value > this.nodeID) && (value < this.right.getNodeId()) ) ||
+			(value == this.nodeID) ) {
+			return this;
+		} else if( (value < this.nodeID) ) {
+			return this.left.findNode(value);
+		}
+		return this.right.findNode(value);
+	}
+
+	private int getNodeId() {
+		return this.nodeID;
+	}
+
+	public OreBuilder getValue() {
+		return this.actualValue;
+	}
+
+	public void addNode(OreBuilder value, int newNodesId) {
+		if( newNodesId < this.nodeID ) {
+			insertLeft(value, newNodesId);
+		} else if( newNodesId > this.nodeID ) {
+			insertRight(value, newNodesId);
+		} else {
+			if( this.actualValue == null ) {
+				this.actualValue = value;
+			} else {
+				OreSpawn.LOGGER.fatal("Multiple Items With Same Node ID Value (%(0,d) - this should not happen (ignoring node!)", newNodesId);
+			}
+		}
+	}
+
+	public TreeNode getRight() {
+		return this.right;
+	}
+
+	public TreeNode getLeft() {
+		return this.left;
+	}
+	
+	public TreeNode getParent() {
+		return this.parent;
+	}
+
+	private void insertRight(OreBuilder value, int newNodesId) {
+		if( this.right == null ) {
+			TreeNode nn = new TreeNode();
+			nn.setParent(this);
+			nn.setNodeId(newNodesId);
+			nn.setValue(value);
+			this.right = nn;
+		} else {
+			this.right.addNode(value, newNodesId);
+		}
+	}
+
+	private void insertLeft(OreBuilder value, int newNodesId) {
+		if( this.left == null ) {
+			TreeNode nn = new TreeNode();
+			nn.setParent(this);
+			nn.setNodeId(newNodesId);
+			nn.setValue(value);
+			this.left = nn;
+		} else {
+			this.left.addNode(value, newNodesId);
+		}
+	}
+
+	private void setParent(TreeNode nn) {
+		this.parent = nn;
+	}
+}

--- a/src/main/java/com/mcmoddev/orespawn/util/TreeNode.java
+++ b/src/main/java/com/mcmoddev/orespawn/util/TreeNode.java
@@ -32,21 +32,33 @@ public class TreeNode {
 		this.setNodeId(0);
 	}
 
-	public TreeNode findNode(int value) {
-		if( ( (value < this.nodeID) && (value > this.left.getNodeId()) ) ||
-			( (value > this.nodeID) && (value < this.right.getNodeId()) ) ||
-			(value == this.nodeID) ) {
-			return this;
-		} else if( (value < this.nodeID) ) {
-			return this.left.findNode(value);
-		}
-		return this.right.findNode(value);
-	}
-
-	private int getNodeId() {
+	public int getNodeId() {
 		return this.nodeID;
 	}
 
+	public TreeNode findNode(int value) {
+		if( value < this.nodeID ) {
+			return this.findLeft(value);
+		} else if( value > this.nodeID) {
+			return this.findRight(value);
+		}
+		return this;
+	}
+
+	private TreeNode findLeft(int value) {
+		if( this.left == null ) return this;
+		if( this.left.getNodeId() < value ) return this;
+		
+ 		return this.left.findNode(value);
+	}
+	
+	private TreeNode findRight(int value) {
+		if( this.right == null ) return this;
+		if( this.right.getNodeId() > value ) return this;
+		
+		return this.right.findNode(value);
+	}
+	
 	public OreBuilder getValue() {
 		return this.actualValue;
 	}

--- a/src/main/java/com/mcmoddev/orespawn/util/TreeNode.java
+++ b/src/main/java/com/mcmoddev/orespawn/util/TreeNode.java
@@ -42,12 +42,12 @@ public class TreeNode {
 		} else if( value > this.nodeID) {
 			return this.findRight(value);
 		}
+		
 		return this;
 	}
 
 	private TreeNode findLeft(int value) {
 		if( this.left == null ) return this;
-		if( this.left.getNodeId() < value ) return this;
 		
  		return this.left.findNode(value);
 	}

--- a/src/main/java/com/mcmoddev/orespawn/worldgen/OreSpawnWorldGen.java
+++ b/src/main/java/com/mcmoddev/orespawn/worldgen/OreSpawnWorldGen.java
@@ -78,7 +78,7 @@ public class OreSpawnWorldGen implements IWorldGenerator {
 					replacement = ReplacementsRegistry.getDimensionDefault(thisDim);
 				}
 				currentFeatureGen.setRandom(random);
-				currentFeatureGen.generate(new ChunkPos(chunkX, chunkZ), world, chunkGenerator, chunkProvider, sE.getFeatureGen().getParameters(), sE.getOres().get(0).getOre(), replacement);
+				currentFeatureGen.generate(new ChunkPos(chunkX, chunkZ), world, chunkGenerator, chunkProvider, sE.getFeatureGen().getParameters(), sE.getOreSpawns(), replacement);
 			}
 		}
 	}


### PR DESCRIPTION
1) Implement a BST for the handling of OreBuilder data being passed to the feature-generators
2) Implement version 1.2 of the config format, implementing "blocks" - an array of objects specifying the block and its chance of being generated - allowing for multi-ore spawns to occur
3) Implement the multi-ore chance in the default generator
4) Move OS3 configs to config/orespawn3 and out of the mc-instance root