### PR TITLE
Corner case fixes

### DIFF
--- a/src/main/java/com/mcmoddev/orespawn/data/Config.java
+++ b/src/main/java/com/mcmoddev/orespawn/data/Config.java
@@ -100,7 +100,7 @@ public class Config {
 	}
 	
 	public static void saveConfig() {
-		if( extractedConfigs.isEmpty() ) {
+		if( !extractedConfigs.isEmpty() ) {
 			saveKnownConfigs();
 		}
 		configuration.save();
@@ -109,6 +109,9 @@ public class Config {
 	private static void saveKnownConfigs() {
 		Gson gson = new GsonBuilder().setPrettyPrinting().create();
 		Path p = FileSystems.getDefault().getPath("config", "orespawn3", "sysconf", "known-configs.json");
+		
+		if( !p.toFile().getParentFile().exists() )
+			p.toFile().mkdirs();
 		
 		File in = p.toFile();
 		

--- a/src/main/java/com/mcmoddev/orespawn/impl/features/ClusterGenerator.java
+++ b/src/main/java/com/mcmoddev/orespawn/impl/features/ClusterGenerator.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Random;
 
 import com.google.gson.JsonObject;
+import com.mcmoddev.orespawn.OreSpawn;
 import com.mcmoddev.orespawn.api.FeatureBase;
 import com.mcmoddev.orespawn.api.IFeature;
 import com.mcmoddev.orespawn.util.BinaryTree;
@@ -57,9 +58,16 @@ public class ClusterGenerator extends FeatureBase implements IFeature {
 		
 		while( tries > 0 ) {
 			if( this.random.nextInt(100) <= frequency ) {
-				int x = blockX + random.nextInt(16) - (maxSpread / 2);
+				int xRand = random.nextInt(16);
+				int zRand = random.nextInt(16);
+				int xzMod = Math.max(xRand, zRand);
+				int mSp = 16 - xzMod;
+				if( maxSpread > 8 )
+					maxSpread = mSp;
+				
+				int x = blockX + random.nextInt(16) - (mSp / 2);
 				int y = random.nextInt(maxHeight - minHeight) + minHeight;
-				int z = blockZ + random.nextInt(16) - (maxSpread / 2);
+				int z = blockZ + random.nextInt(16) - (mSp / 2);
 				int[] params = new int[] { clusterSize, variance, clusterCount, maxSpread, minHeight, maxHeight};
 
 				spawnCluster(ores, new BlockPos(x,y,z), params, random, world, blockReplace);

--- a/src/main/java/com/mcmoddev/orespawn/impl/features/DefaultFeatureGenerator.java
+++ b/src/main/java/com/mcmoddev/orespawn/impl/features/DefaultFeatureGenerator.java
@@ -52,9 +52,9 @@ public class DefaultFeatureGenerator extends FeatureBase implements IFeature {
 		
 		if(freq >= 1){
 			for(int i = 0; i < freq; i++){
-				int x = blockX + random.nextInt(8);
+				int x = blockX + random.nextInt(16);
 				int y = random.nextInt(maxY - minY) + minY;
-				int z = blockZ + random.nextInt(8);
+				int z = blockZ + random.nextInt(16);
 				
 				final int r;
 				if(vari > 0){

--- a/src/main/java/com/mcmoddev/orespawn/impl/features/NormalCloudGenerator.java
+++ b/src/main/java/com/mcmoddev/orespawn/impl/features/NormalCloudGenerator.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Random;
 
 import com.google.gson.JsonObject;
+import com.mcmoddev.orespawn.OreSpawn;
 import com.mcmoddev.orespawn.api.FeatureBase;
 import com.mcmoddev.orespawn.api.IFeature;
 import com.mcmoddev.orespawn.util.BinaryTree;
@@ -55,9 +56,16 @@ public class NormalCloudGenerator extends FeatureBase implements IFeature {
 		
 		while( tries > 0 ) {
 			if( this.random.nextInt(100) <= frequency ) {
-				int x = blockX + random.nextInt(16) - (maxSpread / 2);
+				int xRand = random.nextInt(16);
+				int zRand = random.nextInt(16);
+				int xzMod = Math.max(xRand, zRand);
+				int mSp = 16 - xzMod;
+				if( maxSpread > 8 )
+					maxSpread = mSp;
+				
+				int x = blockX + random.nextInt(16) - (mSp / 2);
 				int y = random.nextInt(maxHeight - minHeight) + minHeight;
-				int z = blockZ + random.nextInt(16) - (maxSpread / 2);
+				int z = blockZ + random.nextInt(16) - (mSp / 2);
 
 				int r = medianSize - variance;
 				if(variance > 0){

--- a/src/main/java/com/mcmoddev/orespawn/impl/features/VeinGenerator.java
+++ b/src/main/java/com/mcmoddev/orespawn/impl/features/VeinGenerator.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Random;
 
 import com.google.gson.JsonObject;
-import com.mcmoddev.orespawn.OreSpawn;
 import com.mcmoddev.orespawn.api.FeatureBase;
 import com.mcmoddev.orespawn.api.IFeature;
 import com.mcmoddev.orespawn.util.BinaryTree;

--- a/src/main/java/com/mcmoddev/orespawn/impl/features/VeinGenerator.java
+++ b/src/main/java/com/mcmoddev/orespawn/impl/features/VeinGenerator.java
@@ -57,9 +57,9 @@ public class VeinGenerator extends FeatureBase implements IFeature {
 		// we have an offset into the chunk but actually need something more
 		while( tries > 0 ) {
 			if( this.random.nextInt(100) <= freq ) {
-				int x = blockX + random.nextInt(8);
+				int x = blockX + random.nextInt(16);
 				int y = random.nextInt(maxY - minY) + minY;
-				int z = blockZ + random.nextInt(8);
+				int z = blockZ + random.nextInt(16);
 
 				final int r;
 				if(vari > 0){

--- a/src/main/java/com/mcmoddev/orespawn/worldgen/OreSpawnWorldGen.java
+++ b/src/main/java/com/mcmoddev/orespawn/worldgen/OreSpawnWorldGen.java
@@ -58,7 +58,7 @@ public class OreSpawnWorldGen implements IWorldGenerator {
 		List<SpawnBuilder> entries = this.dimensions.getOrDefault(thisDim, new ArrayList<>());
 		if( entries.isEmpty() && (thisDim == -1 || thisDim == 1)) return;
 
-		if( (thisDim != -1 && thisDim != 1) && !(this.dimensions.get(OreSpawn.API.dimensionWildcard()).isEmpty()) ) {
+		if( (thisDim != -1 && thisDim != 1) && !(this.dimensions.getOrDefault(OreSpawn.API.dimensionWildcard(), new ArrayList<>()).isEmpty()) ) {
 			entries.addAll(this.dimensions.get(OreSpawn.API.dimensionWildcard()));
 		}
 		


### PR DESCRIPTION
Issues fixed:
1) config write-out would only save the known-configs.json if it was empty because an operator disappeared at some point
2) generation would NPE if no "all overworld" spawns existed - fixed by changing the "get" to a "getOrDefault"
3) config save routine creates the sysconf directory if it does not exist