### PR TITLE
Add uniformity and a bit more stability

### DIFF
--- a/src/main/java/com/mcmoddev/orespawn/data/Constants.java
+++ b/src/main/java/com/mcmoddev/orespawn/data/Constants.java
@@ -29,6 +29,22 @@ public class Constants {
 	public static final String BEDROCK_LAYERS = "Bedrock Thickness";
 	public static final String ORESPAWN_VERSION_CRASH_MESSAGE = "OreSpawn Version";
 	
+	public final class FormatBits {
+		private FormatBits() {}
+		
+		public static final String MAX_SPREAD  = "maxSpread";
+		public static final String MEDIAN_SIZE = "medianSize";
+		public static final String MIN_HEIGHT  = "minHeight";
+		public static final String MAX_HEIGHT  = "maxHeight";
+		public static final String VARIATION   = "variation";
+		public static final String FREQUENCY   = "frequency";
+		public static final String NODE_SIZE   = "size";
+		public static final String ATTEMPTS    = "attempts";
+		public static final String LENGTH      = "length";
+		public static final String WANDER      = "wander";
+		public static final String NODE_COUNT  = "numObjects";
+	}
+	
 	public final class FileBits {
 		private FileBits() {}
 		
@@ -58,13 +74,13 @@ public class Constants {
 		public static final String PARAMETERS = "parameters";
 		public static final String FILE_VERSION = "version";
 		public static final String BLOCK_V2 = "name";
+		
 		public final class V2 {
 			private V2() {}
 			public static final String ENABLED = "enabled";
 			public static final String RETROGEN = "retrogen";
 			public static final String REPLACES = "replaces";
 			public static final String GENERATOR = "generator";
-			public static final String VAR_MARK = "$ref";
 		}
 		public final class BiomeStuff {
 			private BiomeStuff() {}

--- a/src/main/java/com/mcmoddev/orespawn/impl/features/ClusterGenerator.java
+++ b/src/main/java/com/mcmoddev/orespawn/impl/features/ClusterGenerator.java
@@ -6,6 +6,7 @@ import java.util.Random;
 import com.google.gson.JsonObject;
 import com.mcmoddev.orespawn.api.FeatureBase;
 import com.mcmoddev.orespawn.api.IFeature;
+import com.mcmoddev.orespawn.data.Constants;
 import com.mcmoddev.orespawn.util.OreList;
 
 import net.minecraft.block.state.IBlockState;
@@ -42,14 +43,14 @@ public class ClusterGenerator extends FeatureBase implements IFeature {
 		int blockX = chunkX * 16 + 8;
 		int blockZ = chunkZ * 16 + 8;
 
-		int maxSpread    = parameters.get("max-spread").getAsInt();
-		int clusterSize  = parameters.get("cluster-size").getAsInt();
-		int clusterCount = parameters.get("cluster-count").getAsInt();
-		int minHeight    = parameters.get("min-height").getAsInt();
-		int maxHeight    = parameters.get("max-height").getAsInt();
-		int variance     = parameters.get("variance").getAsInt();
-		int frequency    = parameters.get("frequency").getAsInt();
-		int tries        = parameters.get("tries-per-chunk").getAsInt();
+		int maxSpread  = parameters.get(Constants.FormatBits.MAX_SPREAD).getAsInt();
+		int minHeight  = parameters.get(Constants.FormatBits.MIN_HEIGHT).getAsInt();
+		int maxHeight  = parameters.get(Constants.FormatBits.MAX_HEIGHT).getAsInt();
+		int variance   = parameters.get(Constants.FormatBits.VARIATION).getAsInt();
+		int frequency  = parameters.get(Constants.FormatBits.FREQUENCY).getAsInt();
+		int tries      = parameters.get(Constants.FormatBits.ATTEMPTS).getAsInt();
+		int clusterSize  = parameters.get(Constants.FormatBits.NODE_SIZE).getAsInt();
+		int clusterCount = parameters.get(Constants.FormatBits.NODE_COUNT).getAsInt();
 		
 		while( tries > 0 ) {
 			if( this.random.nextInt(100) <= frequency ) {
@@ -206,14 +207,14 @@ public class ClusterGenerator extends FeatureBase implements IFeature {
 	@Override
 	public JsonObject getDefaultParameters() {
 		JsonObject defParams = new JsonObject();
-		defParams.addProperty("max-spread", 16);
-		defParams.addProperty("cluster-size", 8);
-		defParams.addProperty("cluster-count", 8);
-		defParams.addProperty("min-height", 8);
-		defParams.addProperty("max-height", 24);
-		defParams.addProperty("variance", 4);
-		defParams.addProperty("frequency", 25);
-		defParams.addProperty("tries-per-chunk", 8);
+		defParams.addProperty(Constants.FormatBits.MAX_SPREAD, 16);
+		defParams.addProperty(Constants.FormatBits.NODE_SIZE, 8);
+		defParams.addProperty(Constants.FormatBits.NODE_COUNT, 8);
+		defParams.addProperty(Constants.FormatBits.MIN_HEIGHT, 8);
+		defParams.addProperty(Constants.FormatBits.MAX_HEIGHT, 24);
+		defParams.addProperty(Constants.FormatBits.VARIATION, 4);
+		defParams.addProperty(Constants.FormatBits.FREQUENCY, 25);
+		defParams.addProperty(Constants.FormatBits.ATTEMPTS, 8);
 		return defParams;
 	}
 

--- a/src/main/java/com/mcmoddev/orespawn/impl/features/DefaultFeatureGenerator.java
+++ b/src/main/java/com/mcmoddev/orespawn/impl/features/DefaultFeatureGenerator.java
@@ -6,6 +6,7 @@ import java.util.Random;
 import com.google.gson.JsonObject;
 import com.mcmoddev.orespawn.api.FeatureBase;
 import com.mcmoddev.orespawn.api.IFeature;
+import com.mcmoddev.orespawn.data.Constants;
 import com.mcmoddev.orespawn.util.OreList;
 
 import net.minecraft.block.state.IBlockState;
@@ -40,11 +41,11 @@ public class DefaultFeatureGenerator extends FeatureBase implements IFeature {
 		int blockX = chunkX * 16 + 8;
 		int blockZ = chunkZ * 16 + 8;
 		
-		int minY = parameters.get("minHeight").getAsInt();
-		int maxY = parameters.get("maxHeight").getAsInt();
-		int vari = parameters.get("variation").getAsInt();
-		float freq = parameters.get("frequency").getAsFloat();
-		int size = parameters.get("size").getAsInt();
+		int minY = parameters.get(Constants.FormatBits.MIN_HEIGHT).getAsInt();
+		int maxY = parameters.get(Constants.FormatBits.MAX_HEIGHT).getAsInt();
+		int vari = parameters.get(Constants.FormatBits.VARIATION).getAsInt();
+		float freq = parameters.get(Constants.FormatBits.FREQUENCY).getAsFloat();
+		int size = parameters.get(Constants.FormatBits.NODE_SIZE).getAsInt();
 		
 		if(freq >= 1){
 			for(int i = 0; i < freq; i++){
@@ -156,11 +157,11 @@ public class DefaultFeatureGenerator extends FeatureBase implements IFeature {
 	@Override
 	public JsonObject getDefaultParameters() {
 		JsonObject defParams = new JsonObject();
-		defParams.addProperty("minHeight", 0);
-		defParams.addProperty("maxHeight", 256);
-		defParams.addProperty("variation", 16);
-		defParams.addProperty("frequency", 0.5);
-		defParams.addProperty("size", 8);
+		defParams.addProperty(Constants.FormatBits.MIN_HEIGHT, 0);
+		defParams.addProperty(Constants.FormatBits.MAX_HEIGHT, 256);
+		defParams.addProperty(Constants.FormatBits.VARIATION, 16);
+		defParams.addProperty(Constants.FormatBits.FREQUENCY, 0.5);
+		defParams.addProperty(Constants.FormatBits.NODE_SIZE, 8);
 		return defParams;
 	}
 

--- a/src/main/java/com/mcmoddev/orespawn/impl/features/NormalCloudGenerator.java
+++ b/src/main/java/com/mcmoddev/orespawn/impl/features/NormalCloudGenerator.java
@@ -6,6 +6,7 @@ import java.util.Random;
 import com.google.gson.JsonObject;
 import com.mcmoddev.orespawn.api.FeatureBase;
 import com.mcmoddev.orespawn.api.IFeature;
+import com.mcmoddev.orespawn.data.Constants;
 import com.mcmoddev.orespawn.util.OreList;
 
 import net.minecraft.block.state.IBlockState;
@@ -41,13 +42,13 @@ public class NormalCloudGenerator extends FeatureBase implements IFeature {
 		int blockX = chunkX * 16 + 8;
 		int blockZ = chunkZ * 16 + 8;
 
-		int maxSpread  = parameters.get("max-spread").getAsInt();
-		int medianSize = parameters.get("median-size").getAsInt();
-		int minHeight  = parameters.get("min-height").getAsInt();
-		int maxHeight  = parameters.get("max-height").getAsInt();
-		int variance   = parameters.get("variance").getAsInt();
-		int frequency  = parameters.get("frequency").getAsInt();
-		int tries      = parameters.get("tries-per-chunk").getAsInt();
+		int maxSpread  = parameters.get(Constants.FormatBits.MAX_SPREAD).getAsInt();
+		int medianSize = parameters.get(Constants.FormatBits.MEDIAN_SIZE).getAsInt();
+		int minHeight  = parameters.get(Constants.FormatBits.MIN_HEIGHT).getAsInt();
+		int maxHeight  = parameters.get(Constants.FormatBits.MAX_HEIGHT).getAsInt();
+		int variance   = parameters.get(Constants.FormatBits.VARIATION).getAsInt();
+		int frequency  = parameters.get(Constants.FormatBits.FREQUENCY).getAsInt();
+		int tries      = parameters.get(Constants.FormatBits.ATTEMPTS).getAsInt();
 		
 		while( tries > 0 ) {
 			if( this.random.nextInt(100) <= frequency ) {
@@ -115,13 +116,13 @@ public class NormalCloudGenerator extends FeatureBase implements IFeature {
 	@Override
 	public JsonObject getDefaultParameters() {
 		JsonObject defParams = new JsonObject();
-		defParams.addProperty("max-spread", 16);
-		defParams.addProperty("median-size", 8);
-		defParams.addProperty("min-height", 8);
-		defParams.addProperty("max-height", 24);
-		defParams.addProperty("variance", 4);
-		defParams.addProperty("frequency", 25);
-		defParams.addProperty("tries-per-chunk", 8);
+		defParams.addProperty(Constants.FormatBits.MAX_SPREAD, 16);
+		defParams.addProperty(Constants.FormatBits.MEDIAN_SIZE, 8);
+		defParams.addProperty(Constants.FormatBits.MIN_HEIGHT, 8);
+		defParams.addProperty(Constants.FormatBits.MAX_HEIGHT, 24);
+		defParams.addProperty(Constants.FormatBits.VARIATION, 4);
+		defParams.addProperty(Constants.FormatBits.FREQUENCY, 25);
+		defParams.addProperty(Constants.FormatBits.ATTEMPTS, 8);
 		return defParams;
 	}
 

--- a/src/main/java/com/mcmoddev/orespawn/impl/features/VeinGenerator.java
+++ b/src/main/java/com/mcmoddev/orespawn/impl/features/VeinGenerator.java
@@ -6,6 +6,7 @@ import java.util.Random;
 import com.google.gson.JsonObject;
 import com.mcmoddev.orespawn.api.FeatureBase;
 import com.mcmoddev.orespawn.api.IFeature;
+import com.mcmoddev.orespawn.data.Constants;
 import com.mcmoddev.orespawn.util.OreList;
 
 import net.minecraft.block.state.IBlockState;
@@ -41,14 +42,14 @@ public class VeinGenerator extends FeatureBase implements IFeature {
 		int blockX = chunkX * 16 + 8;
 		int blockZ = chunkZ * 16 + 8;
 
-		int minY = parameters.get("minHeight").getAsInt();
-		int maxY = parameters.get("maxHeight").getAsInt();
-		int vari = parameters.get("variation").getAsInt();
-		int freq = parameters.get("frequency").getAsInt();
-		int tries = parameters.get("attempts").getAsInt();
-		int length = parameters.get("length").getAsInt();
-		int wander = parameters.get("wander").getAsInt();
-		int nodeSize = parameters.get("node-size").getAsInt();
+		int minY = parameters.get(Constants.FormatBits.MIN_HEIGHT).getAsInt();
+		int maxY = parameters.get(Constants.FormatBits.MAX_HEIGHT).getAsInt();
+		int vari = parameters.get(Constants.FormatBits.VARIATION).getAsInt();
+		int freq = parameters.get(Constants.FormatBits.FREQUENCY).getAsInt();
+		int tries = parameters.get(Constants.FormatBits.ATTEMPTS).getAsInt();
+		int length = parameters.get(Constants.FormatBits.LENGTH).getAsInt();
+		int wander = parameters.get(Constants.FormatBits.WANDER).getAsInt();
+		int nodeSize = parameters.get(Constants.FormatBits.NODE_SIZE).getAsInt();
 		
 		// we have an offset into the chunk but actually need something more
 		while( tries > 0 ) {
@@ -223,14 +224,14 @@ public class VeinGenerator extends FeatureBase implements IFeature {
 	@Override
 	public JsonObject getDefaultParameters() {
 		JsonObject defParams = new JsonObject();
-		defParams.addProperty("minHeight", 0);
-		defParams.addProperty("maxHeight", 256);
-		defParams.addProperty("variation", 16);
-		defParams.addProperty("frequency", 50); // in this, frequency is an int
-		defParams.addProperty("length", 16);
-		defParams.addProperty("node-size", 3);
-		defParams.addProperty("wander", 75); // how much this can wander
-		defParams.addProperty("attempts", 8); // how often to attempt to make a vein
+		defParams.addProperty(Constants.FormatBits.MIN_HEIGHT, 0);
+		defParams.addProperty(Constants.FormatBits.MAX_HEIGHT, 256);
+		defParams.addProperty(Constants.FormatBits.VARIATION, 16);
+		defParams.addProperty(Constants.FormatBits.FREQUENCY, 50);
+		defParams.addProperty(Constants.FormatBits.ATTEMPTS, 8);
+		defParams.addProperty(Constants.FormatBits.LENGTH, 16);
+		defParams.addProperty(Constants.FormatBits.WANDER, 75);
+		defParams.addProperty(Constants.FormatBits.NODE_SIZE, 3);
 		return defParams;
 	}
 

--- a/src/main/java/com/mcmoddev/orespawn/json/os3/IOS3Reader.java
+++ b/src/main/java/com/mcmoddev/orespawn/json/os3/IOS3Reader.java
@@ -1,10 +1,14 @@
 package com.mcmoddev.orespawn.json.os3;
 
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Random;
 import java.util.Map.Entry;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.mcmoddev.orespawn.data.Constants;
 import com.mcmoddev.orespawn.data.Constants.ConfigNames;
 import com.mcmoddev.orespawn.util.OS3V2PresetStorage;
 
@@ -130,4 +134,23 @@ public interface IOS3Reader {
 		return getStorage().getSymbolSection(section, item);
 	}
 
+	default String getBlockName(JsonObject ore) {
+		String key;
+		if( ore.has(Constants.ConfigNames.BLOCK) ) key = Constants.ConfigNames.BLOCK;
+		else if( ore.has(Constants.ConfigNames.BLOCKID) ) key = Constants.ConfigNames.BLOCKID;
+		else return String.format("ore-%d", new Random().nextInt());
+		
+		return ore.get(key).getAsString();
+	}
+
+	default String getBlockNameMulti( JsonObject ore ) {
+		List<String> rv = new LinkedList<>();
+		JsonArray ores = ore.get(Constants.ConfigNames.BLOCKS).getAsJsonArray();
+		
+		for( JsonElement o : ores ) {
+			rv.add(o.getAsJsonObject().get(Constants.ConfigNames.BLOCK_V2).getAsString());
+		}
+		
+		return String.join("-", new String[1]);
+	}
 }

--- a/src/main/java/com/mcmoddev/orespawn/json/os3/readers/OS3V11Reader.java
+++ b/src/main/java/com/mcmoddev/orespawn/json/os3/readers/OS3V11Reader.java
@@ -37,6 +37,7 @@ public class OS3V11Reader implements IOS3Reader {
 				oreOut.add("biomes", biomeObj);
 				
 				copyOverSingleBlock(ore,oreOut);
+				oreOut.addProperty("name", getBlockName(ore));
 				
 				dimData.add(oreOut);
 			}

--- a/src/main/java/com/mcmoddev/orespawn/json/os3/readers/OS3V12Reader.java
+++ b/src/main/java/com/mcmoddev/orespawn/json/os3/readers/OS3V12Reader.java
@@ -32,6 +32,7 @@ public class OS3V12Reader implements IOS3Reader {
 				ore.entrySet().forEach( prop -> oreOut.add(prop.getKey(), prop.getValue()));
 				
 				dimData.add(oreOut);
+				oreOut.addProperty("name", getBlockNameMulti(ore));
 			}
 			retVal.getAsJsonObject("dimensions").add(Integer.toString(dimension), dimData);
 		}

--- a/src/main/java/com/mcmoddev/orespawn/json/os3/readers/OS3V1Reader.java
+++ b/src/main/java/com/mcmoddev/orespawn/json/os3/readers/OS3V1Reader.java
@@ -34,11 +34,12 @@ public final class OS3V1Reader implements IOS3Reader {
 				
 				copyOverSingleBlock(ore,oreOut);
 				oreOut.add("biomes", new JsonObject());
+				oreOut.addProperty("name", getBlockName(ore));
 				dimData.add(oreOut);
 			}
 			retVal.getAsJsonObject("dimensions").add(Integer.toString(dimension), dimData);
 		}
 		
 		return retVal;
-	}
+	}	
 }

--- a/src/main/java/com/mcmoddev/orespawn/json/os3/readers/OS3V2Reader.java
+++ b/src/main/java/com/mcmoddev/orespawn/json/os3/readers/OS3V2Reader.java
@@ -58,6 +58,7 @@ public class OS3V2Reader implements IOS3Reader {
 			lw.getAsJsonArray(ConfigNames.DIMENSIONS).getAsJsonArray().forEach(
 					dim -> {
 						JsonObject nw = new JsonObject();
+						nw.addProperty("name", entry.getKey());
 						entry.getValue().getAsJsonObject().entrySet().stream()
 						.filter( e -> !e.getKey().equals(ConfigNames.DIMENSIONS) )
 						.forEach( ent -> nw.add( ent.getKey(), ent.getValue()));


### PR DESCRIPTION
1) make feature-generator parameters with the same purpose share the same name
2) make the format the parameter names take uniform
3) add a try/catch to the internal-format parser so that the system can recover from issues in a single entry and possibly point users at the entry that caused the issue