### PR TITLE
Event handlers need to be re-entrant - this is a quick fix

### DIFF
--- a/src/main/java/com/mcmoddev/orespawn/EventHandlers.java
+++ b/src/main/java/com/mcmoddev/orespawn/EventHandlers.java
@@ -165,7 +165,10 @@ public class EventHandlers {
 		if (ev.phase == Phase.END) {
 			Deque<ChunkPos> keys = Queues.newArrayDeque(chunks.keySet());
 
-			for (int c = 0; c < 5 && !chunks.isEmpty(); c++) {
+			// if 'chunks' is empty, exit
+			// if 'keys' is empty, exit
+			// exit after 5 items, regardless
+			for (int c = 0; c < 5 && !chunks.isEmpty() && !keys.isEmpty(); c++) {
 				ChunkPos p = keys.pop();
 				List<String> spawns = chunks.remove(p);
 				


### PR DESCRIPTION
Seems that event handlers are not run in order and can interrupt each other.
This is the only reason that "keys" could be empty when "chunks" is not.
Add a check to early exit if "keys" is empty. This should fix the crash that several have reported.

Fixes #134 