### PR TITLE
don't let block updates go when placing a block - it causes issues.

### DIFF
--- a/src/main/java/com/mcmoddev/orespawn/api/FeatureBase.java
+++ b/src/main/java/com/mcmoddev/orespawn/api/FeatureBase.java
@@ -103,7 +103,8 @@ public class FeatureBase extends IForgeRegistryEntry.Impl<IFeature> {
 			final Biome thisBiome = world.getBiome(coord);
 
 			if (replacer.test(targetBlock) && spawnData.biomeAllowed(thisBiome.getRegistryName())) {
-				world.setBlockState(coord, oreBlock);
+				// don't send block update, send to client, don't re-render, observers don't see the change
+				world.setBlockState(coord, oreBlock, 0x22);
 				return true;
 			} else {
 				return false;


### PR DESCRIPTION
This is a possible fix for both cascading world-gen and the recursive crash that is hitting some other users. No clue if it works for the crash, but since the cascade was caused by block-updates triggering fluids to update, it should fix that. Sadly this also introduces a minor rendering bug.