### PR TITLE
final sync in prep for new CF release

### DIFF
--- a/src/main/java/com/mcmoddev/orespawn/worldgen/OreSpawnWorldGen.java
+++ b/src/main/java/com/mcmoddev/orespawn/worldgen/OreSpawnWorldGen.java
@@ -24,8 +24,7 @@ public class OreSpawnWorldGen implements IWorldGenerator {
 		OreSpawn.API.getSpawns(thisDim).stream().filter(ISpawnEntry::isEnabled)
 				.filter(sb -> !Config.getBoolean(Constants.RETROGEN_KEY)
 						|| (sb.isRetrogen() || Config.getBoolean(Constants.FORCE_RETROGEN_KEY)))
-				.forEach(spawn -> 
-					spawn.generate(random, world, chunkGenerator, chunkProvider,
+				.forEach(spawn -> spawn.generate(random, world, chunkGenerator, chunkProvider,
 							new ChunkPos(chunkX, chunkZ)));
 	}
 }


### PR DESCRIPTION
D3nnis3n reported that both the current CF release version and build 177 on the Maven fail to have any world-gen in his private pack when OS3 is there and using 3.3.0 (which the pack originally used) crashed immediately. Sent him a custom-build that had extra debugging and there was no issue. As there are other bugs that have been fixed since the last release, lets make this official...