### PR TITLE
Fix cascading world gen lag

### DIFF
--- a/src/main/java/com/mcmoddev/orespawn/api/FeatureBase.java
+++ b/src/main/java/com/mcmoddev/orespawn/api/FeatureBase.java
@@ -128,7 +128,7 @@ public class FeatureBase extends IForgeRegistryEntry.Impl<IFeature> {
 
 			if (replacer.test(targetBlock) && spawnData.biomeAllowed(thisBiome.getRegistryName())) {
 				// don't send block update, send to client, don't re-render, observers don't see the change
-				world.setBlockState(coord, oreBlock, 0x22);
+				world.setBlockState(coord, oreBlock, 22);
 				return true;
 			} else {
 				return false;


### PR DESCRIPTION
World#setBlockState jd:
```
* Flag 1 will cause a block update. Flag 2 will send the change to clients. Flag 4 will prevent the block from
* being re-rendered, if this is a client world. Flag 8 will force any re-renders to run on the main thread instead
* of the worker pool, if this is a client world and flag 4 is clear. Flag 16 will prevent observers from seeing
* this change. Flags can be OR-ed
```

https://github.com/MinecraftModDevelopmentMods/OreSpawn/blob/c5cfa56c50226673b0301e9bb3e4d153267a08c2/src/main/java/com/mcmoddev/orespawn/api/FeatureBase.java#L130-L131

means 2 | 4 | 16 which is 22 (base 10). However 0x22 (base 16) is 34 (base 10).

Stacktrace:

```
[java.lang.Thread:dumpStack:1336]: java.lang.Exception: Stack trace
[java.lang.Thread:dumpStack:1336]: at java.lang.Thread.dumpStack(Thread.java:1336)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.world.chunk.Chunk.handler$zzk004$onInit(Chunk.java:2823)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.world.chunk.Chunk.logCascadingWorldGeneration(Chunk.java)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.world.chunk.Chunk.func_186034_a(Chunk.java:1006)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.world.chunk.Chunk.func_186030_a(Chunk.java:999)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.world.gen.ChunkProviderServer.redirect$bci000$impl$populateChunkThroughSponge(ChunkProviderServer.java:2082)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.world.gen.ChunkProviderServer.func_186025_d(ChunkProviderServer.java:157)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.world.World.func_72964_e(World.java:310)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.world.World.func_175726_f(World.java:305)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.world.WorldServer.func_180495_p(WorldServer.java:5582)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.world.World.func_190529_b(World.java:581)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.world.World.func_190522_c(World.java:484)
[java.lang.Thread:dumpStack:1336]: at org.spongepowered.common.event.tracking.PhaseTracker.setBlockState(PhaseTracker.java:1000)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.world.WorldServer.func_180501_a(WorldServer.java:5037)
[java.lang.Thread:dumpStack:1336]: at com.mcmoddev.orespawn.api.FeatureBase.spawnOrCache(FeatureBase.java:131)
[java.lang.Thread:dumpStack:1336]: at com.mcmoddev.orespawn.api.FeatureBase.spawnMungeInner(FeatureBase.java:267)
[java.lang.Thread:dumpStack:1336]: at com.mcmoddev.orespawn.api.FeatureBase.spawnMungeSW(FeatureBase.java:280)
[java.lang.Thread:dumpStack:1336]: at com.mcmoddev.orespawn.impl.features.VeinGenerator.doSpawnFill(VeinGenerator.java:560)
[java.lang.Thread:dumpStack:1336]: at com.mcmoddev.orespawn.impl.features.VeinGenerator.spawnOre(VeinGenerator.java:549)
[java.lang.Thread:dumpStack:1336]: at com.mcmoddev.orespawn.impl.features.VeinGenerator.spawnVein(VeinGenerator.java:172)
[java.lang.Thread:dumpStack:1336]: at com.mcmoddev.orespawn.impl.features.VeinGenerator.generate(VeinGenerator.java:88)
[java.lang.Thread:dumpStack:1336]: at com.mcmoddev.orespawn.impl.os3.SpawnEntry.generate(SpawnEntry.java:95)
[java.lang.Thread:dumpStack:1336]: at com.mcmoddev.orespawn.worldgen.OreSpawnWorldGen.lambda$generate$1(OreSpawnWorldGen.java:28)
[java.lang.Thread:dumpStack:1336]: at java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
[java.lang.Thread:dumpStack:1336]: at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175)
[java.lang.Thread:dumpStack:1336]: at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175)
[java.lang.Thread:dumpStack:1336]: at java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:948)
[java.lang.Thread:dumpStack:1336]: at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
[java.lang.Thread:dumpStack:1336]: at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
[java.lang.Thread:dumpStack:1336]: at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
[java.lang.Thread:dumpStack:1336]: at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
[java.lang.Thread:dumpStack:1336]: at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
[java.lang.Thread:dumpStack:1336]: at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:485)
[java.lang.Thread:dumpStack:1336]: at com.mcmoddev.orespawn.worldgen.OreSpawnWorldGen.generate(OreSpawnWorldGen.java:27)
[java.lang.Thread:dumpStack:1336]: at net.minecraftforge.fml.common.registry.GameRegistry.redirect$zzd000$forgeImpl$startTimingOnGenerate(GameRegistry.java:575)
[java.lang.Thread:dumpStack:1336]: at net.minecraftforge.fml.common.registry.GameRegistry.generateWorld(GameRegistry.java:167)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.world.chunk.Chunk.func_186034_a(Chunk.java:1020)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.world.chunk.Chunk.func_186030_a(Chunk.java:999)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.world.gen.ChunkProviderServer.redirect$bci000$impl$populateChunkThroughSponge(ChunkProviderServer.java:2082)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.world.gen.ChunkProviderServer.func_186025_d(ChunkProviderServer.java:157)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.server.management.PlayerChunkMapEntry.redirect$bcb000$forgeImpl$UpdateLoadedChunk(PlayerChunkMapEntry.java:1576)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.server.management.PlayerChunkMapEntry.func_187268_a(PlayerChunkMapEntry.java:126)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.server.management.PlayerChunkMap.func_72693_b(SourceFile:147)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.world.WorldServer.func_72835_b(WorldServer.java:227)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:756)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:397)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:668)
[java.lang.Thread:dumpStack:1336]: at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:526)
[java.lang.Thread:dumpStack:1336]: at java.lang.Thread.run(Thread.java:748)
```

EDIT: I'm not going to sign the CLA. 