### PR TITLE
make it so that it merges entries instead of replacing them

### DIFF
--- a/src/main/java/com/mcmoddev/orespawn/data/ReplacementsRegistry.java
+++ b/src/main/java/com/mcmoddev/orespawn/data/ReplacementsRegistry.java
@@ -185,7 +185,12 @@ public class ReplacementsRegistry {
 				}
 			});
 
-			final IReplacementEntry replacer = new ReplacementEntry("orespawn:" + entName, blocks);
+			ResourceLocation checkName= new ResourceLocation("orespawn", entName);
+			if (registry.containsKey(checkName)) {
+				List<IBlockState> existingReps = getReplacement(checkName.toString()).getEntries();
+				blocks.addAll(existingReps);
+			}
+			final IReplacementEntry replacer = new ReplacementEntry(checkName.toString(), blocks);
 			registry.register(replacer);
 		});
 	}

--- a/src/main/java/com/mcmoddev/orespawn/data/ReplacementsRegistry.java
+++ b/src/main/java/com/mcmoddev/orespawn/data/ReplacementsRegistry.java
@@ -185,9 +185,9 @@ public class ReplacementsRegistry {
 				}
 			});
 
-			ResourceLocation checkName= new ResourceLocation("orespawn", entName);
+			final ResourceLocation checkName= new ResourceLocation("orespawn", entName);
 			if (registry.containsKey(checkName)) {
-				List<IBlockState> existingReps = getReplacement(checkName.toString()).getEntries();
+				final List<IBlockState> existingReps = getReplacement(checkName.toString()).getEntries();
 				blocks.addAll(existingReps);
 			}
 			final IReplacementEntry replacer = new ReplacementEntry(checkName.toString(), blocks);


### PR DESCRIPTION
The current iteration of the Replacements Registry flatly overrides entries with the same name rather than merging them - lets fix that.