### PR TITLE
Refactor to split out to individual spawn generator calls.

### DIFF
--- a/src/main/java/com/mcmoddev/orespawn/EventHandlers.java
+++ b/src/main/java/com/mcmoddev/orespawn/EventHandlers.java
@@ -15,6 +15,7 @@ import com.google.common.collect.MapDifference;
 import com.google.common.collect.Maps;
 import com.mcmoddev.orespawn.data.Config;
 import com.mcmoddev.orespawn.data.Constants;
+import com.mcmoddev.orespawn.worldgen.OreSpawnFeatureGenerator;
 
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.Tuple;
@@ -189,6 +190,13 @@ public class EventHandlers {
 
 	}
 
+	private OreSpawnFeatureGenerator findSpawn(final String spawnName) {
+		for (OreSpawnFeatureGenerator ofg : OreSpawn.API.getGenerators()) {
+			if (ofg.getSpawnName().matches(spawnName)) return ofg;
+		}
+		return null;
+	}
+	
 	private void runBits(final Tuple<ChunkPos, List<String>> tup, World world) {
 		final ChunkPos p = tup.getFirst();
 		final List<String> spawns = tup.getSecond();
@@ -199,8 +207,10 @@ public class EventHandlers {
 		// re-seed with something totally new :P
 		random.setSeed((((random.nextLong() >> 4 + 1) + p.x) + ((random.nextLong() >> 2 + 1) + p.z))
 				^ world.getSeed());
-		spawns.stream().forEach(s -> OreSpawn.API.getSpawn(s).generate(random, world,
-				chunkGenerator, chunkProvider, p));
+		spawns.stream().forEach(s -> {
+			OreSpawnFeatureGenerator feature = findSpawn(s);
+			if (feature != null) feature.generate(random, p.x, p.z, world, chunkGenerator, chunkProvider);
+		});
 	}
 
 	@SubscribeEvent

--- a/src/main/java/com/mcmoddev/orespawn/OreSpawn.java
+++ b/src/main/java/com/mcmoddev/orespawn/OreSpawn.java
@@ -1,13 +1,8 @@
 package com.mcmoddev.orespawn;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import com.mcmoddev.orespawn.api.os3.ISpawnBuilder;
 import com.mcmoddev.orespawn.api.os3.OS3API;
 import com.mcmoddev.orespawn.api.plugin.PluginLoader;
 import com.mcmoddev.orespawn.commands.AddOreCommand;
@@ -19,7 +14,7 @@ import com.mcmoddev.orespawn.data.Constants;
 import com.mcmoddev.orespawn.data.FeatureRegistry;
 import com.mcmoddev.orespawn.impl.os3.OS3APIImpl;
 import com.mcmoddev.orespawn.worldgen.FlatBedrock;
-import com.mcmoddev.orespawn.worldgen.OreSpawnWorldGen;
+import com.mcmoddev.orespawn.worldgen.OreSpawnFeatureGenerator;
 
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.Mod;
@@ -53,14 +48,9 @@ public class OreSpawn {
 	public static final OS3API API = new OS3APIImpl();
 	static final EventHandlers eventHandlers = new EventHandlers();
 	public static final FeatureRegistry FEATURES = new FeatureRegistry();
-	protected static final Map<Integer, List<ISpawnBuilder>> spawns = new HashMap<>();
 
 	static final FlatBedrock flatBedrock = new FlatBedrock();
-
-	public static Map<Integer, List<ISpawnBuilder>> getSpawns() {
-		return spawns;
-	}
-
+	
 	@EventHandler
 	public void onFingerprintViolation(final FMLFingerprintViolationEvent event) {
 		LOGGER.warn("Invalid fingerprint detected!");
@@ -76,8 +66,9 @@ public class OreSpawn {
 			GameRegistry.registerWorldGenerator(flatBedrock, 100);
 		}
 
-		GameRegistry.registerWorldGenerator(new OreSpawnWorldGen(), 100);
-
+		API.getAllSpawns().entrySet().parallelStream()
+		           .forEach(ent -> GameRegistry.registerWorldGenerator(new OreSpawnFeatureGenerator(ent.getValue(), ent.getKey()), 100));
+		
 		if (Config.getBoolean(Constants.RETROGEN_KEY)
 				|| Config.getBoolean(Constants.REPLACE_VANILLA_OREGEN)
 				|| Config.getBoolean(Constants.RETRO_BEDROCK)) {

--- a/src/main/java/com/mcmoddev/orespawn/api/os3/OS3API.java
+++ b/src/main/java/com/mcmoddev/orespawn/api/os3/OS3API.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import com.mcmoddev.orespawn.api.IFeature;
 import com.mcmoddev.orespawn.data.PresetsStorage;
+import com.mcmoddev.orespawn.worldgen.OreSpawnFeatureGenerator;
 
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.ResourceLocation;
@@ -63,4 +64,8 @@ public interface OS3API {
 	List<String> getSpawnsForFile(String fileName);
 
 	Map<Path, List<String>> getSpawnsByFile();
+	
+	void addGenerator(final OreSpawnFeatureGenerator generator);
+	
+	List<OreSpawnFeatureGenerator> getGenerators();
 }

--- a/src/main/java/com/mcmoddev/orespawn/api/os3/OS3FeatureGenerator.java
+++ b/src/main/java/com/mcmoddev/orespawn/api/os3/OS3FeatureGenerator.java
@@ -1,0 +1,6 @@
+package com.mcmoddev.orespawn.api.os3;
+
+public interface OS3FeatureGenerator {
+	public ISpawnEntry getSpawnData();
+	public String getSpawnName();
+}

--- a/src/main/java/com/mcmoddev/orespawn/impl/os3/OS3APIImpl.java
+++ b/src/main/java/com/mcmoddev/orespawn/impl/os3/OS3APIImpl.java
@@ -7,6 +7,7 @@ import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -38,6 +39,7 @@ import com.mcmoddev.orespawn.data.FeatureRegistry;
 import com.mcmoddev.orespawn.data.PresetsStorage;
 import com.mcmoddev.orespawn.data.ReplacementsRegistry;
 import com.mcmoddev.orespawn.json.OreSpawnReader;
+import com.mcmoddev.orespawn.worldgen.OreSpawnFeatureGenerator;
 
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.crash.CrashReport;
@@ -46,6 +48,7 @@ import net.minecraft.util.ResourceLocation;
 public class OS3APIImpl implements OS3API {
 
 	private static final Map<ResourceLocation, ISpawnEntry> spawns;
+	private static final List<OreSpawnFeatureGenerator> generators;
 	private static final FeatureRegistry features;
 	private static final ReplacementsRegistry replacements;
 	private static final PresetsStorage presets;
@@ -57,6 +60,7 @@ public class OS3APIImpl implements OS3API {
 		features = new FeatureRegistry();
 		replacements = new ReplacementsRegistry();
 		presets = new PresetsStorage();
+		generators = new LinkedList<>();
 	}
 
 	public OS3APIImpl() {
@@ -115,6 +119,16 @@ public class OS3APIImpl implements OS3API {
 		}
 	}
 
+	@Override
+	public void addGenerator(final OreSpawnFeatureGenerator generator) {
+		generators.add(generator);
+	}
+	
+	@Override
+	public List<OreSpawnFeatureGenerator> getGenerators() {
+		return new LinkedList<OreSpawnFeatureGenerator>(generators);
+	}
+	
 	@Override
 	public void addSpawn(final ISpawnEntry spawnEntry) {
 		if (spawnEntry != null) {

--- a/src/main/java/com/mcmoddev/orespawn/worldgen/OreSpawnFeatureGenerator.java
+++ b/src/main/java/com/mcmoddev/orespawn/worldgen/OreSpawnFeatureGenerator.java
@@ -1,0 +1,46 @@
+package com.mcmoddev.orespawn.worldgen;
+
+import java.util.Random;
+
+import com.mcmoddev.orespawn.api.os3.ISpawnEntry;
+import com.mcmoddev.orespawn.api.os3.OS3FeatureGenerator;
+import com.mcmoddev.orespawn.data.Config;
+import com.mcmoddev.orespawn.data.Constants;
+
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.IChunkProvider;
+import net.minecraft.world.gen.IChunkGenerator;
+import net.minecraftforge.fml.common.IWorldGenerator;
+import net.minecraft.util.math.ChunkPos;
+
+public class OreSpawnFeatureGenerator implements IWorldGenerator, OS3FeatureGenerator {
+	private final ISpawnEntry spawn;
+	private final String name;
+	
+	public OreSpawnFeatureGenerator( final ISpawnEntry spawn, final String name ) {
+		this.spawn = spawn;
+		this.name = name;
+	}
+	
+	@Override
+	public void generate(Random random, int chunkX, int chunkZ, World world, IChunkGenerator chunkGenerator,
+			IChunkProvider chunkProvider) {
+		final int thisDim = world.provider.getDimension();
+
+		if (((!Config.getBoolean(Constants.RETROGEN_KEY) && 
+				(this.spawn.isRetrogen() || Config.getBoolean(Constants.FORCE_RETROGEN_KEY)))) && 
+				this.spawn.isEnabled() && this.spawn.dimensionAllowed(thisDim)) {
+				this.spawn.generate(random, world, chunkGenerator, chunkProvider, new ChunkPos(chunkX, chunkZ));
+		}
+	}
+
+	@Override
+	public ISpawnEntry getSpawnData() {
+		return this.spawn;
+	}
+
+	@Override
+	public String getSpawnName() {
+		return this.name;
+	}
+}


### PR DESCRIPTION
Generation currently has one massive bit of code doing everything. This has led to several inefficiencies and some "attempts to generate after the chunk has been unloaded" when players were moving extremely fast over newly generated terrain. Fixing that also lets us have the code in a much better state for the planned 1.16 port.

The next step is to resolve the CWG issues and fix the "gridded placement" issue as well.