### PR TITLE
change two calls to LOGGER.fatal() to LOGGER.error()

### DIFF
--- a/src/main/java/com/mcmoddev/orespawn/api/FeatureBase.java
+++ b/src/main/java/com/mcmoddev/orespawn/api/FeatureBase.java
@@ -58,7 +58,7 @@ public class FeatureBase extends IForgeRegistryEntry.Impl<IFeature> {
 	protected boolean spawn(final IBlockState oreBlock, final World world, final BlockPos coord,
 			final int dimension, final boolean cacheOverflow, final ISpawnEntry spawnData) {
 		if (oreBlock == null) {
-			OreSpawn.LOGGER.fatal("FeatureBase.spawn() called with a null ore!");
+			OreSpawn.LOGGER.error("FeatureBase.spawn() called with a null ore!");
 			return false;
 		}
 
@@ -74,8 +74,8 @@ public class FeatureBase extends IForgeRegistryEntry.Impl<IFeature> {
 
 		final BlockPos np = mungeFixYcoord(coord);
 
-		if (coord.getY() >= world.getHeight()) {
-			OreSpawn.LOGGER.warn("Asked to spawn {} above build limit at {}", oreBlock, coord);
+		if (world.isValid(coord)) {
+			OreSpawn.LOGGER.warn("Asked to spawn {} outside of world at {}", oreBlock, coord);
 			return false;
 		}
 
@@ -136,7 +136,7 @@ public class FeatureBase extends IForgeRegistryEntry.Impl<IFeature> {
 	private void spawnNoCheck(final IBlockState oreBlock, final World world, final BlockPos coord,
 			final int dimension, final ISpawnEntry spawnData) {
 		if (oreBlock == null) {
-			OreSpawn.LOGGER.fatal("FeatureBase.spawn() called with a null ore!");
+			OreSpawn.LOGGER.error("FeatureBase.spawnNoCheck() called with a null ore!");
 			return;
 		}
 

--- a/src/main/java/com/mcmoddev/orespawn/impl/os3/SpawnBuilder.java
+++ b/src/main/java/com/mcmoddev/orespawn/impl/os3/SpawnBuilder.java
@@ -219,7 +219,7 @@ public class SpawnBuilder implements ISpawnBuilder {
 			if (this.biomes == null) this.biomes = new BiomeBuilder().setAcceptAll().create();
 			if (this.replacements == null) this.replacements = com.mcmoddev.orespawn.OreSpawn.API.getReplacement("default");
 			if (this.feature == null) {
-				com.mcmoddev.orespawn.OreSpawn.LOGGER.fatal("Spawn entry {} does not have a stated feature, ignoring.", this.spawnName);
+				com.mcmoddev.orespawn.OreSpawn.LOGGER.error("Spawn entry {} does not have a stated feature, ignoring.", this.spawnName);
 				return null;
 			}
 			return new SpawnEntry(this.spawnName, this.enabled, this.retrogen, this.dimensions,


### PR DESCRIPTION
also fixes a potential crash that would occur if you tried to spawn a block below y=0 or beyond x,z=30M